### PR TITLE
DKIM milter on submission ports only

### DIFF
--- a/common/etc/e-smith/templates/etc/postfix/main.cf/00template_vars
+++ b/common/etc/e-smith/templates/etc/postfix/main.cf/00template_vars
@@ -73,12 +73,14 @@
     $mynetworks = '';
     $mynetworks_style = '';
 
-    # Smtpd_milters
-    # Milter used by opendkim
-    #
+    # DKIM signing disabled on public SMTP server
+    @smtpd_milters = ();
+
+    # DKIM signature for sendmail command and submission server
     if($opendkim{'status'} eq 'enabled') {
-        push @smtpd_milters, 'unix:/var/run/opendkim/milter';
         push @non_smtpd_milters, 'unix:/var/run/opendkim/milter';
+        push @submission_smtpd_milters, 'unix:/var/run/opendkim/milter';
     }
+
     '';
 }

--- a/common/etc/e-smith/templates/etc/postfix/main.cf/70smtpd_milters
+++ b/common/etc/e-smith/templates/etc/postfix/main.cf/70smtpd_milters
@@ -1,7 +1,7 @@
-
 #
 # 70smtpd_milters -- see 00template_vars
 #
-
 smtpd_milters = { join (",\n ", @smtpd_milters); }
 non_smtpd_milters = { join (",\n ", @non_smtpd_milters); }
+submission_smtpd_milters = { join (",\n ", @submission_smtpd_milters); }
+

--- a/common/etc/e-smith/templates/etc/postfix/master.cf/00template_vars
+++ b/common/etc/e-smith/templates/etc/postfix/master.cf/00template_vars
@@ -16,6 +16,7 @@
       smtpd_sender_restrictions=
       smtpd_recipient_restrictions=$submission_recipient_policy
       strict_rfc821_envelopes=no
+      smtpd_milters=$submission_smtpd_milters
     );
 
     # The maximum number of smtpd processes spawned:

--- a/filter/etc/e-smith/templates/etc/postfix/main.cf/01template_vars_rspamd
+++ b/filter/etc/e-smith/templates/etc/postfix/main.cf/01template_vars_rspamd
@@ -1,7 +1,11 @@
 {
-    # Smtpd_milters
-    # Milter used by rspamd
     #
-    push @smtpd_milters, 'unix:/var/run/rspamd/worker-proxy' if $rspamd{'status'} eq 'enabled';
+    # 01template_vars_rspamd -- prepend rspamd filter checks
+    #
+    if($rspamd{'status'} eq 'enabled') {
+        unshift @smtpd_milters, 'unix:/var/run/rspamd/worker-proxy' ;
+        unshift @submission_smtpd_milters, 'unix:/var/run/rspamd/worker-proxy' ;
+    }
+
     '';
 }

--- a/filter/etc/e-smith/templates/etc/postfix/main.cf/70smtpd_milters
+++ b/filter/etc/e-smith/templates/etc/postfix/main.cf/70smtpd_milters
@@ -1,6 +1,0 @@
-
-#
-# 70smtpd_milters -- see 0Xtemplate_vars
-#
-
-smtpd_milters = { join (",\n ", @smtpd_milters); }


### PR DESCRIPTION
Disable DKIM milter on port 25 to avoid signatures on messages from untrusted clients.

NethServer/dev#5394