### PR TITLE
Expand local IP following trusted-networks-modify

### DIFF
--- a/createlinks-filter
+++ b/createlinks-filter
@@ -100,5 +100,5 @@ event_actions('migration-import', qw(
 #
 # trusted-networks-modify event
 #
-
-event_templates( 'trusted-networks-modify', '/etc/httpd/conf.d/rspamd.conf');
+event_services('trusted-networks-modify','rspamd' => 'reload');
+event_templates( 'trusted-networks-modify', '/etc/rspamd/rspamd.conf');


### PR DESCRIPTION
Event trusted-networks-modify is used to expand the local_addrs  and to reload rspamd