### PR TITLE
Send rspamd log to /var/log/maillog

### DIFF
--- a/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/30Logging
+++ b/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/30Logging
@@ -2,8 +2,8 @@
 # Rspamd Log
 #
 logging \{
-    type = "file";
-    filename = "$LOGDIR/rspamd.log";
+    type = "syslog";
+    facility = "mail";
     .include "$CONFDIR/logging.inc"
     .include(try=true; priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/logging.inc"
     .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/logging.inc"


### PR DESCRIPTION
Previously, `amavisd` was configured to log to maillog: I wouldn't change this convention by now.

NethServer/dev#5394