### PR TITLE
rspamd: use unbound for all DNS queries (skip dnsmasq)

### DIFF
--- a/filter/etc/e-smith/templates/etc/dnsmasq.conf/26unbound_rbl
+++ b/filter/etc/e-smith/templates/etc/dnsmasq.conf/26unbound_rbl
@@ -1,4 +1,0 @@
-# forward RBL queries to localhost unbound
-server=/uribl.com/127.0.0.1#10053
-server=/dnswl.org/127.0.0.1#10053
-server=/spamhaus.org/127.0.0.1#10053

--- a/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/20Options
+++ b/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/20Options
@@ -34,6 +34,7 @@ dns \{
     timeout = 1s;
     sockets = 16;
     retransmits = 5;
+    nameserver = ["127.0.0.1:10053:1"];
 \}
 tempdir = "/tmp";
 url_tld = "$\{PLUGINSDIR\}/effective_tld_names.dat";


### PR DESCRIPTION
Rspamd supports usage of custom DNS servers for RBL queries. We already have Unbound, we used it for spamassassin going through dnsmasq. Now we can remove the custom dnsmasq configuration and route all queries directly to Unbound.

NethServer/dev#5394