### PR TITLE
Removal of spam_header setting

### DIFF
--- a/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/60WorkerProxy
+++ b/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/60WorkerProxy
@@ -17,7 +17,6 @@ worker "rspamd_proxy" \{
 
     # number of worker
     count = {$rspamd{MaxProcesses} || '1'};
-    spam_header = "X-Spam-Flag";
     max_retries = 5;
 \}
 


### PR DESCRIPTION
This option doesn't work as intended to create  the custom header we need (X-Spam-Flag). Therefore I would like to remove it from rspamd.conf and still continue to use the former one in milter-header.conf

https://github.com/NethServer/dev/issues/5478