### PR TITLE
MxRecordStatus default "disabled"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,11 +115,10 @@ Postfix example: ::
     MessageQueueLifetime=4
     MessageSizeMax=20000000
     MessageSizeMin=1048576
-    MxRecordStatus=enabled
+    MxRecordStatus=disabled
     ContentInspectionType=default
     ConnectionsLimit=
     ConnectionsLimitPerIp=
-    MxRecordStatus=enabled
     SystemUserRecipientStatus=disabled
 
 * ``AccessPolicies``: A comma separated list of values. Obsoletes
@@ -138,8 +137,13 @@ Postfix example: ::
 * ``AlwaysBccAddress``: an email address that always receives a
   message copy (controlled by ``AlwaysBccStatus``).
 
-* ``MxRecordStatus {enabled,disabled}`` Push smtp, imap, pop, pop3 into /etc/hosts.
-  They masquerade DNS A records in the LAN.
+* ``MxRecordStatus {enabled,disabled}``
+    If ``enabled``, push smtp, imap, pop, pop3 into ``/etc/hosts`` and register
+    ``smtp.DOMAIN`` as MX record for LAN hosts. Warning! ``enabled`` has some
+    pitfalls: (1) it masquerades DNS A records in the LAN, (2) it does not work
+    correctly with Letsencrypt certificates and (3) it does not work with GSSAPI
+    authentication. Since 7.5.1804 the default (and recommended setting) is
+    ``disabled``.
 
 * ``SystemUserRecipientStatus {enabled,disabled}`` ``enabled``,
   accept from any network the recipient addresses formed by user

--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,7 @@ Postfix example: ::
     If ``enabled``, push smtp, imap, pop, pop3 into ``/etc/hosts`` and register
     ``smtp.DOMAIN`` as MX record for LAN hosts. Warning! ``enabled`` has some
     pitfalls: (1) it masquerades DNS A records in the LAN, (2) it does not work
-    correctly with Letsencrypt certificates and (3) it does not work with GSSAPI
+    correctly with Let's Encrypt certificates and (3) it does not work with GSSAPI
     authentication. Since 7.5.1804 the default (and recommended setting) is
     ``disabled``.
 

--- a/server/etc/e-smith/db/configuration/defaults/postfix/MxRecordStatus
+++ b/server/etc/e-smith/db/configuration/defaults/postfix/MxRecordStatus
@@ -1,1 +1,1 @@
-enabled
+disabled

--- a/server/etc/e-smith/templates/etc/dnsmasq.conf/40mx_record
+++ b/server/etc/e-smith/templates/etc/dnsmasq.conf/40mx_record
@@ -1,6 +1,11 @@
 #
 # 40mx_record
 #
-mx-host={$DomainName},{join('.', 'smtp', $DomainName)}
+mx-host={$DomainName}{
+    $OUT = '';
+    if($postfix{'MxRecordStatus'} && $postfix{'MxRecordStatus'} eq 'enabled') {
+        $OUT = ',smtp.' . $DomainName;
+    }
+}
 
 


### PR DESCRIPTION
Since 7.5.1804 the default (and recommended setting) is `disabled` because  `enabled`

1. masquerades DNS A records in the LAN,
2. may not work with LetsEncrypt certificates,
3. may not work with GSSAPI authentication.

NethServer/dev#5490