### PR TITLE
Iterate over domains DB to configure MX records

### DIFF
--- a/server/etc/e-smith/templates/etc/dnsmasq.conf/40mx_record
+++ b/server/etc/e-smith/templates/etc/dnsmasq.conf/40mx_record
@@ -1,11 +1,15 @@
 #
 # 40mx_record
 #
-mx-host={$DomainName}{
-    $OUT = '';
+{
     if($postfix{'MxRecordStatus'} && $postfix{'MxRecordStatus'} eq 'enabled') {
-        $OUT = ',smtp.' . $DomainName;
+        $OUT = "mx-host=$DomainName,smtp.$DomainName\n";
+    } else {
+        use esmith::DomainsDB;
+        $OUT = '';
+        foreach (esmith::DomainsDB->open_ro()->get_all_by_prop('type' => 'domain')) {
+            $OUT .= 'mx-host=' . $_->key . "\n";
+        }
     }
 }
-
 


### PR DESCRIPTION
This is a proposal for new Email 2 installations: provide an MX record for any configured domain (both local delivery and relay). The previous PR (#43) configures only the "primary" mail domain (from host FQDN).

NethServer/dev#5490