### PR TITLE
Catch rspamc timeouts and other errors

### DIFF
--- a/getmail/etc/e-smith/templates/getmailrc/40rspamd
+++ b/getmail/etc/e-smith/templates/getmailrc/40rspamd
@@ -9,10 +9,10 @@
         $OUT = <<EOF;
 [filter-1]
 type = Filter_classifier
-path = /usr/bin/rspamc
-arguments = ("-h", "localhost:11334", "-e", "/usr/bin/grep -x -F 'Action: reject'")
-exitcodes_drop = (0, )
-exitcodes_keep = (1, )
+path = /usr/bin/rspamc-check
+arguments = ("--ham", "-t", "120", "-h", "localhost:11334")
+exitcodes_drop = (99, )
+exitcodes_keep = (0, )
 user = _rspamd
 group = _rspamd
 EOF

--- a/getmail/usr/bin/rspamc-check
+++ b/getmail/usr/bin/rspamc-check
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+
+#
+# Copyright (C) 2018 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+if [[ $1 == --ham || -z $1 ]]; then
+    program='/^Action: reject/ { p;q99 } ; /^Action: / { p;q0 } ; $ { q1 }'
+elif [[ $1 == --spam ]]; then
+    program='/^Action: reject/ { p;q0 } ; /^Action: / { p;q99 } ; $ { q1 }'
+else
+    echo "[ERROR] invalid argument. Usage $0 [--ham|--spam] [args for rspamc...]" 1>&2
+    exit 2
+fi
+
+shift
+
+/usr/bin/rspamc "$@" | /usr/bin/sed -n "${program}"
+
+exit $?


### PR DESCRIPTION
Avoid false positives when rspamc fails for any reason. The special exit
code 99 corresponds to a spam condition.

NethServer/dev#5513