### PR TITLE
Fix DKIM signature when disclaimer is added

### DIFF
--- a/common/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Mail_Domain.php
+++ b/common/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Mail_Domain.php
@@ -15,4 +15,3 @@ $L['valid_relay_notprimarydomain'] = 'The local mailbox domain cannot be relayed
 $L['OpenDkimStatus_label'] = 'Sign outbound messages with DomainKeys Identified Mail (DKIM)';
 $L['DkimSelector_label'] = '1. Add a TXT record to your public DNS service provider with key "${0}"';
 $L['DkimKey_label'] = '2. Copy and paste the following text in the record data (RDATA) section';
-$L['Cannot_enable_dkim_and_disclaimer_both'] = 'The legal note and DKIM settings can not be both enabled at the same time';

--- a/common/usr/share/nethesis/NethServer/Module/Mail/Domain/Modify.php
+++ b/common/usr/share/nethesis/NethServer/Module/Mail/Domain/Modify.php
@@ -71,12 +71,6 @@ class Modify extends \Nethgui\Controller\Table\Modify
         ) {
             $report->addValidationErrorMessage($this, 'domain', 'valid_relay_notprimarydomain');
         }
-        if ($this->getRequest()->isMutation() &&
-            $this->parameters['DisclaimerStatus'] === 'enabled' &&
-            $this->parameters['OpenDkimStatus'] === 'enabled') {
-            $report->addValidationErrorMessage($this, 'domain', 'Cannot_enable_dkim_and_disclaimer_both');
-        }
-
     }
 
     public function readDkimFile()

--- a/createlinks-disclaimer
+++ b/createlinks-disclaimer
@@ -26,6 +26,7 @@ my $event = 'nethserver-mail2-disclaimer-update';
 event_actions ( $event, 'initialize-default-databases' => '00');
 event_templates($event,'/etc/postfix/disclaimer');
 event_templates($event,'/etc/postfix/master.cf');
+event_templates($event, '/etc/postfix/main.cf');
 event_services($event, 'postfix' => 'restart');
 
 # expand the script

--- a/disclaimer/etc/e-smith/templates/etc/postfix/main.cf/01dkim_milter_disclaimer
+++ b/disclaimer/etc/e-smith/templates/etc/postfix/main.cf/01dkim_milter_disclaimer
@@ -1,0 +1,7 @@
+{
+    #
+    # 01dkim_milter_disclaimer -- strip dkim milter from submission ports
+    #
+    @submission_smtpd_milters = grep { $_ ne 'unix:/var/run/opendkim/milter' } @submission_smtpd_milters;
+    '';
+}


### PR DESCRIPTION
This PR proposal disables the submission DKIM milter when the optional disclaimer package is installed, and reverts the fix of NethServer/dev#5514

The DKIM signature issue seems due to our Postfix configuration which double signs outbound messages:

1. the first time with `submission_smtpd_milters` (used by SMTP port 587)
2. the second time with `non_smtpd_milters` (used by `sendmail`)

```text
[root@vm8 ~]# postconf -n | grep smtpd_milt
non_smtpd_milters = unix:/var/run/opendkim/milter
smtpd_milters = unix:/var/run/rspamd/worker-proxy
submission_smtpd_milters = unix:/var/run/rspamd/worker-proxy, unix:/var/run/opendkim/milter
```

NethServer/dev#5528