### PR TITLE
Fix non existing event name in mail2

### DIFF
--- a/server/etc/e-smith/events/actions/nethserver-mail-migrate-domains
+++ b/server/etc/e-smith/events/actions/nethserver-mail-migrate-domains
@@ -117,8 +117,8 @@ foreach my $srcRecord ($srcAccountsDb->users(), $srcAccountsDb->groups(), $srcAc
 
 }
 
-if( ! esmith::event::event_signal('nethserver-mail-server-update')) {
-    warn("[ERROR] nethserver-mail-server-update event failed\n");
+if( ! esmith::event::event_signal('nethserver-mail-server-save')) {
+    warn("[ERROR] nethserver-mail-server-save event failed\n");
     $errors++;
 }
 

--- a/server/etc/e-smith/events/actions/nethserver-mail-server-migrate
+++ b/server/etc/e-smith/events/actions/nethserver-mail-server-migrate
@@ -64,8 +64,8 @@ if( ! $spamassassinRecord) {
 }
 
 # Activate changes:
-if( ! esmith::event::event_signal('nethserver-mail-server-update')) {
-    warn "[ERROR] nethserver-mail-server-update failed!";
+if( ! esmith::event::event_signal('nethserver-mail-server-save')) {
+    warn "[ERROR] nethserver-mail-server-save failed!";
     $errors ++;
 }
 $dstConfigDb->reload();


### PR DESCRIPTION
The sme8 migration procedure fails with nethserver-mail2-server RPM, producing the following log trace:

    Jul 18 10:09:36 mail esmith::event[19980]: Can't open directory /etc/e-smith/events/nethserver-mail-server-update
    Jul 18 10:09:36 mail esmith::event[19980]: Action: /etc/e-smith/events/migration-import/S30nethserver-mail-migrate-domains FAILED: 2 [0.34568]
    [...]
    Jul 18 10:09:36 mail esmith::event[19980]: Can't open directory /etc/e-smith/events/nethserver-mail-server-update
    Jul 18 10:09:36 mail esmith::event[19980]: Action: /etc/e-smith/events/migration-import/S30nethserver-mail-server-migrate FAILED: 2 [0.152202]

As the fix is trivial I propose to trigger the `save` event because it is more quick and we will not revert the change when "mail2" is renamed "mail".
