### PR TITLE
Do not disable history stored to redis

### DIFF
--- a/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf.override/10base
+++ b/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf.override/10base
@@ -20,6 +20,7 @@ else {
         ($file eq '..') ||
         ($file eq 'antivirus.conf') ||
         ($file eq 'multimap.conf')  ||
+        ($file eq 'history_redis.conf')  ||
         ($file eq 'redis.conf'));
 
     $file =~ s/\.conf$//;


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/5551

We must not disable the history redis storage, else the obsolete file storage is used (deprecated and less information)