### PR TITLE
Return an empty sieve-script if no local mail-server is installed

### DIFF
--- a/filter/etc/e-smith/templates/var/lib/nethserver/sieve-scripts/before.sieve/90mail-server_not_installed
+++ b/filter/etc/e-smith/templates/var/lib/nethserver/sieve-scripts/before.sieve/90mail-server_not_installed
@@ -1,0 +1,9 @@
+
+{
+  #
+  # return an empty sieve-script if no local mail-server is installed
+  #
+  
+  	return ' ';
+  
+}

--- a/nethserver-mail2.spec
+++ b/nethserver-mail2.spec
@@ -154,6 +154,7 @@ EOF
 cat >>filter.lst <<'EOF'
 %dir %{_nseventsdir}/%{name}-filter-update
 %dir %attr(0755,redis,redis) /var/lib/redis/rspamd
+%dir %attr(0770,root,vmail) %{_nsstatedir}/sieve-scripts
 %config(noreplace) %attr(0440,_rspamd,_rspamd) /etc/rspamd/dkim_whitelist.inc
 %config(noreplace) %attr(0440,_rspamd,_rspamd) /etc/rspamd/local.d/mid.inc
 %config(noreplace) %attr(0440,_rspamd,_rspamd) /etc/rspamd/spf_whitelist.inc


### PR DESCRIPTION
NethServer/dev#5562

provide a template fragment to expand if no local mail-server is installed


the filter package “wants” to expand the/var/lib/nethserver/sieve-scripts/before.sieve as suggested by me; NethServer@24aa635
but if the server package is not installed (lets say you want to run a MTA for a server elsewhere) there is no template to expand for the filter package.

journalctl **before** this fix/propasal

```
... esmith::event[2650]: expanding /var/lib/nethserver/sieve-scripts/before.sieve
... esmith::event[2650]: ERROR: Cannot create output file //var/lib/nethserver/sieve-scripts/before.sieve.2652 No such file or directory
... esmith::event[2650]:  at /etc/e-smith/events/actions/generic_template_expand line 64.
... esmith::event[2650]: [WARNING] expansion of /var/lib/nethserver/sieve-scripts/b
```

**after** this fix/propasal

```
... esmith::event[2697]: expanding /etc/rspamd/override.d/metrics.conf
... esmith::event[2697]: expanding /var/lib/nethserver/sieve-scripts/before.sieve
... esmith::event[2697]: Action:  /etc/e-smith/events/actions/generic_template_expand SUCCESS [0.507015]
```