### PR TITLE
Return an empty sieve-script if no local mail-server is installed

### DIFF
--- a/common/etc/e-smith/templates/var/lib/nethserver/sieve-scripts/before.sieve/90mail-server_not_installed
+++ b/common/etc/e-smith/templates/var/lib/nethserver/sieve-scripts/before.sieve/90mail-server_not_installed
@@ -1,0 +1,4 @@
+  
+  # Empty template fragment for compatibility for (all possible) 
+  # orders of installations of mail-server and mail-filter packages 
+  

--- a/nethserver-mail2.spec
+++ b/nethserver-mail2.spec
@@ -127,6 +127,7 @@ mkdir -p getmail/var/lib/getmail
 
 cat >>common.lst <<'EOF'
 %dir %{_nseventsdir}/%{name}-common-update
+%dir %attr(0770,root,vmail) %{_nsstatedir}/sieve-scripts
 %dir %attr(2775,root,adm) %{_nsstatedir}/mail-disclaimers
 %config %attr (0440,root,root) %{_sysconfdir}/sudoers.d/20_nethserver_mail_common
 EOF


### PR DESCRIPTION
NethServer/dev#5562

- provide a template fragment to expand if no local mail server is installed,
- this fragment is placed in mail-common

see also:
https://github.com/NethServer/nethserver-mail/pull/61
