### PR TITLE
Fix ownership of sieve directory

### DIFF
--- a/nethserver-mail2.spec
+++ b/nethserver-mail2.spec
@@ -218,10 +218,15 @@ done
 %doc COPYING
 %doc README.rst
 
+%pre common 
+# ensure vmail group exists for sieve-directory
+getent group vmail > /dev/null || groupadd -r vmail
+
 %pre server
-# ensure vmail user exists:
+# ensure vmail user and group exists:
+getent group vmail > /dev/null || groupadd -r vmail
 if ! id vmail >/dev/null 2>&1 ; then
-   useradd -c 'Virtual mailboxes owner' -r -M -d /var/lib/nethserver/vmail -s /sbin/nologin vmail
+   useradd -g vmail -c 'Virtual mailboxes owner' -r -M -d /var/lib/nethserver/vmail -s /sbin/nologin vmail
 fi
 
 # add vmail group to postfix user


### PR DESCRIPTION
The creation of the sieve-directory is moved to mail-common, however the `vmail user` is created during `%pre server`.  After trails, with includes creating this directory twice (in common and server package)  this came out as the most reliable with a minimum impact;

the vmail group is created (in advance) inn the common package, the user in the server package where it is needed.