### PR TITLE
Catch rspamc errors

### DIFF
--- a/getmail/etc/e-smith/templates/getmailrc/40rspamd
+++ b/getmail/etc/e-smith/templates/getmailrc/40rspamd
@@ -9,7 +9,7 @@
         $OUT = <<EOF;
 [filter-1]
 type = Filter_external
-path = /usr/bin/rspamc
+path = /usr/bin/rspamc-getmail
 arguments = ("--mime", "-t", "120", "-h", "localhost:11334")
 exitcodes_drop = (99, )
 exitcodes_keep = (0, )

--- a/getmail/usr/bin/rspamc-getmail
+++ b/getmail/usr/bin/rspamc-getmail
@@ -20,17 +20,7 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-if [[ $1 == --ham || -z $1 ]]; then
-    program='/^Action: reject/ { p;q99 } ; /^Action: / { p;q0 } ; $ { q1 }'
-elif [[ $1 == --spam ]]; then
-    program='/^Action: reject/ { p;q0 } ; /^Action: / { p;q99 } ; $ { q1 }'
-else
-    echo "[ERROR] invalid argument. Usage $0 [--ham|--spam] [args for rspamc...]" 1>&2
-    exit 2
-fi
 
-shift
-
-/usr/bin/rspamc "$@" | /usr/bin/sed -n "${program}"
+/usr/bin/rspamc "$@" | /usr/bin/sed '/^X-Spam-Error:/ q2'
 
 exit $?


### PR DESCRIPTION
Return a temporary failure condition if the spam filter fails for
an unknown reason.

NethServer/dev#5572