### PR TITLE
.spec: remove obsoletes nethserver-smarthost

### DIFF
--- a/nethserver-mail.spec
+++ b/nethserver-mail.spec
@@ -109,8 +109,6 @@ BuildArch: noarch
 Requires: nethserver-base
 Requires: cyrus-sasl-plain
 Requires: postfix
-Provides: nethserver-smarthost = %{version}
-Obsoletes: nethserver-smarthost < %{version}
 %description smarthost
 Configures Postfix to send outbound messages through the given MTA (smarthost),
 with SMTP/AUTH and StartTLS encryption.


### PR DESCRIPTION
The smarthost package name was already nethserver-mail-smarthost.
No need to use "Obsoletes" and "Provides" tags.

NethServer/dev#5589