### PR TITLE
How to re-train Bayes filters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -552,3 +552,11 @@ If an account provider is configured, the default access policy to rspamd UI is
 granting access also to ``admin`` user and members of the ``domain admins`` group.
 Type ``config show admins`` for details.
 
+Bayesian rules upgrade to rspamd
+--------------------------------
+
+Each ``Junk`` (or ``junkmail``) folder from users' accounts, if present, can be
+used to train the Rspamd Bayesian filter database, by running the attached
+script: ::
+
+  bash /usr/share/doc/nethserver-mail-server-*/bayes_training.sh

--- a/migration/bayes_training.sh
+++ b/migration/bayes_training.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2018 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+JUNKFOLDER=$(/sbin/e-smith/config getprop dovecot SpamFolder)
+
+if [[ -z "${JUNKFOLDER}" ]]; then
+    echo "[WARNING] junk folder is not defined."
+    exit 0
+fi
+
+trap "echo '[WARNING] Interrupt!'; exit 0" INT
+
+for USER in /var/lib/nethserver/vmail/*; do
+  USER=$(basename $USER)
+
+  echo "Loading $USER.."
+ 
+  doveadm search -u $USER mailbox "${JUNKFOLDER}" ALL | while read guid uid; do
+     doveadm -f pager fetch -u $USER text mailbox-guid $guid uid $uid \
+         | sed '1d;$d' \
+         | rspamc -t 60 -h localhost:11334 learn_spam
+  done
+
+done

--- a/nethserver-mail.spec
+++ b/nethserver-mail.spec
@@ -222,6 +222,7 @@ done
 %doc README.rst
 %doc bats/
 %doc migration/sync_maildirs.sh
+%doc migration/bayes_training.sh
 
 %files ipaccess -f ipaccess.lst
 %defattr(-,root,root)


### PR DESCRIPTION
During upgrade from amavis to rspamd the Junk folders contents can be
used to train the Bayesian filters.