### PR TITLE
Fix IP-based scoring

### DIFF
--- a/p3scan/usr/bin/rspamc-p3scan
+++ b/p3scan/usr/bin/rspamc-p3scan
@@ -25,7 +25,7 @@ use strict;
 my $have_headers = 0;
 my $headers = '';
 
-open(my $rh, '-|', qw(/usr/bin/rspamc), @ARGV);
+open(my $rh, '-|', qw(/usr/bin/rspamc -i 127.0.0.1), @ARGV);
 
 while(<$rh>) {
     if($have_headers) {


### PR DESCRIPTION
As the SMTP envelope is not available, assume the message was sent from
the local host to avoid strict IP checks.

This is just an attempt to make p3scan more backward compatible with the old version.

https://github.com/NethServer/dev/issues/5606