### PR TITLE
Arm integration ease timeout startup clamd

### DIFF
--- a/filter/usr/lib/systemd/system/clamd@rspamd.service.d/nethserver.conf
+++ b/filter/usr/lib/systemd/system/clamd@rspamd.service.d/nethserver.conf
@@ -6,3 +6,4 @@ User=_rspamd
 Group=mail
 RuntimeDirectory=clamd@rspamd
 RuntimeDirectoryMode=0755
+TimeoutStartSec=300


### PR DESCRIPTION
NethServer/dev#5610

On low resource systems the default systemd timeout can be to short to start clamd. 
You may argue you should not install it but I can't stop people from doing it anyway.
With this minor adjustment at least the clamd@rspamd.service starts up properly.

(Nice side effect is the frequency of automatic restarts are restrained a bit if something is wrong)