### PR TITLE
Allow smtp access for trusted network

### DIFF
--- a/common/etc/e-smith/templates/etc/postfix/access.cidr/20TrustedNetwork
+++ b/common/etc/e-smith/templates/etc/postfix/access.cidr/20TrustedNetwork
@@ -1,0 +1,13 @@
+#
+# 20TrustedNetwork -- IP based policy for Network
+#
+{
+    if ($postfix{'AccessPolicies'} =~ 'trustednetworks') {
+        use NethServer::TrustedNetworks;
+        $CIDR = join(" ", NethServer::TrustedNetworks::list_cidr());
+
+        foreach (split(/ /, $CIDR)) {
+            $OUT .= sprintf("%s OK\n", $_);
+        }
+    }
+}

--- a/common/etc/e-smith/templates/etc/postfix/access.cidr/20TrustedNetwork
+++ b/common/etc/e-smith/templates/etc/postfix/access.cidr/20TrustedNetwork
@@ -4,9 +4,9 @@
 {
     if ($postfix{'AccessPolicies'} =~ 'trustednetworks') {
         use NethServer::TrustedNetworks;
-        $CIDR = join(" ", NethServer::TrustedNetworks::list_cidr());
+        @CIDR = NethServer::TrustedNetworks::list_cidr();
 
-        foreach (split(/ /, $CIDR)) {
+        foreach (@CIDR) {
             $OUT .= sprintf("%s OK\n", $_);
         }
     }


### PR DESCRIPTION
NethServer/dev#5644

do not relax helo directly like in https://github.com/NethServer/nethserver-mail/pull/92/files but push trusted network to /etc/postfix/access.cidr