### PR TITLE
Getmail warnings prevent to delete emails in remote account 

### DIFF
--- a/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/10limits
+++ b/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/10limits
@@ -13,7 +13,7 @@ service anvil \{
 \}
 
 service auth \{
-    client_limit = { $dovecot{MaxProcesses} * 5 }
+    client_limit = { $dovecot{MaxProcesses} * 6 }
 \}
 
 

--- a/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/50quota
+++ b/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/50quota
@@ -9,7 +9,6 @@
     my $quotaDefaultSize = int(($dovecot{QuotaDefaultSize} << 10 ) / 10.0);
 
     return <<EOF;
-mail_plugins = \$mail_plugins quota
 
 protocol imap {
   mail_plugins = \$mail_plugins quota imap_quota

--- a/server/etc/e-smith/templates/etc/systemd/system/dovecot.service.d/limits.conf/10base
+++ b/server/etc/e-smith/templates/etc/systemd/system/dovecot.service.d/limits.conf/10base
@@ -2,6 +2,6 @@
 # 10base
 #
 [Service]
-LimitNOFILE={ $dovecot{MaxProcesses} * 5 }
+LimitNOFILE={ $dovecot{MaxProcesses} * 6 }
 
 


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/5679

The warning prevents getmail to delete the email, fix the warning and  the emails are deleted