### PR TITLE
Add Dynamic Group Alias resolution postfix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,8 @@ Postfix example: ::
 * ``SenderValidation {enabled,disabled}``, default ``disabled``,
   checks the SMTP sender is consistent with /etc/login_maps 
   and /etc/login_maps.pcre contents.
+* ``DynamicGroupAlias {enabled,disabled}``, default ``disabled``,
+   if ``enabled``, create distribution lists based on system groups.
 
 Dovecot example: ::
 

--- a/createlinks-server
+++ b/createlinks-server
@@ -76,6 +76,7 @@ event_templates('nethserver-mail-server-update',
 event_actions('nethserver-mail-server-update', qw(
 	      initialize-default-databases 00
           nethserver-mail-default-domain-create 01
+          nethserver-mail-server-postfix-get-group-enable 20
 	      nethserver-mail-postmap-update 30
           nethserver-mail-create-opendkim-key 40
           nethserver-sssd-initkeytabs 50

--- a/server/etc/e-smith/db/configuration/defaults/postfix/DynamicGroupAlias
+++ b/server/etc/e-smith/db/configuration/defaults/postfix/DynamicGroupAlias
@@ -1,0 +1,1 @@
+disabled

--- a/server/etc/e-smith/events/actions/nethserver-mail-server-postfix-get-group-enable
+++ b/server/etc/e-smith/events/actions/nethserver-mail-server-postfix-get-group-enable
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright (C) 2019 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+systemctl enable --now postfix-get-group.socket

--- a/server/etc/e-smith/templates/etc/postfix/main.cf/20virtual_domains
+++ b/server/etc/e-smith/templates/etc/postfix/main.cf/20virtual_domains
@@ -28,7 +28,7 @@ virtual_mailbox_maps = proxy:unix:passwd.byname {
     }
     return '';
 }
-virtual_alias_maps = hash:/etc/postfix/virtual
+virtual_alias_maps = hash:/etc/postfix/virtual { ($postfix{DynamicGroupAlias} || '') eq 'enabled' ? 'tcp:127.0.0.1:14444' : '' }
 
 # Message delivery transport that the local(8)
 # delivery agent should use for mailbox delivery:

--- a/server/usr/lib/systemd/system/postfix-get-group.socket
+++ b/server/usr/lib/systemd/system/postfix-get-group.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description = postfix-get-group server
+
+[Socket]
+ListenStream = 127.0.0.1:14444
+Accept = yes
+
+[Install]
+WantedBy = sockets.target

--- a/server/usr/lib/systemd/system/postfix-get-group@.service
+++ b/server/usr/lib/systemd/system/postfix-get-group@.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=postfix-get-group server service
+
+[Service]
+User=nobody
+ExecStart=/usr/libexec/nethserver/postfix-get-group
+StandardInput=socket

--- a/server/usr/libexec/nethserver/postfix-get-group
+++ b/server/usr/libexec/nethserver/postfix-get-group
@@ -28,7 +28,8 @@ do
             if [ -n "$group" ]; then
                 user_list=$(getent  group "$group")
                 if [ "$?" -ne 2 ]; then
-                    echo 200 "$(echo  -n $user_list |  cut -d ':' -f 4)"
+                    msg=$(echo  -n "$user_list" |  cut -d ':' -f 4)
+                    echo 200 "${msg:0:4091}"
                 else
                     echo 500 Group%20not%20found
                 fi

--- a/server/usr/libexec/nethserver/postfix-get-group
+++ b/server/usr/libexec/nethserver/postfix-get-group
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright (C) 2019 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+IFS=" "
+
+while read -r action group err
+do
+    if [ -z "$err" ]; then
+        if [ "$action" = "get" ]; then
+            if [ -n "$group" ]; then
+                user_list=$(getent  group "$group")
+                if [ "$?" -ne 2 ]; then
+                    echo 200 "$(echo  -n $user_list |  cut -d ':' -f 4)"
+                else
+                    echo 500 Group%20not%20found
+                fi
+            else
+                echo 400 Group%20name%20not%20provided
+            fi
+        else
+            echo 400 Action%20not%20recognized
+        fi
+    else
+        echo 400 Too%20many%20arguments
+    fi
+done

--- a/server/usr/libexec/nethserver/postfix-get-group
+++ b/server/usr/libexec/nethserver/postfix-get-group
@@ -23,23 +23,19 @@ IFS=" "
 
 while read -r action group err
 do
-    if [ -z "$err" ]; then
-        if [ "$action" = "get" ]; then
-            if [ -n "$group" ]; then
-                user_list=$(getent  group "$group")
-                if [ "$?" -ne 2 ]; then
-                    msg=$(echo  -n "$user_list" |  cut -d ':' -f 4)
-                    echo 200 "${msg:0:4091}"
-                else
-                    echo 500 Group%20not%20found
-                fi
-            else
-                echo 400 Group%20name%20not%20provided
-            fi
-        else
-            echo 400 Action%20not%20recognized
-        fi
-    else
+    if [ -n "$err" ]; then
         echo 400 Too%20many%20arguments
+    elif [ "$action" != "get" ]; then
+        echo 400 Action%20not%20recognized
+    elif [ -z "$group" ]; then
+        echo 400 Group%20name%20not%20provided
+    else
+        user_list=$(getent group "$group")
+        if [ "$?" -ne "2" ]; then
+            msg=$(echo  -n "$user_list" |  cut -d ':' -f 4)
+            echo 200 "${msg:0:4091}"
+        else
+            echo 500 Group%20not%20found
+        fi
     fi
 done

--- a/server/usr/libexec/nethserver/postfix-get-group
+++ b/server/usr/libexec/nethserver/postfix-get-group
@@ -24,11 +24,11 @@ IFS=" "
 while read -r action group err
 do
     if [ -n "$err" ]; then
-        echo 400 Too%20many%20arguments
+        echo 500 Too%20many%20arguments
     elif [ "$action" != "get" ]; then
-        echo 400 Action%20not%20recognized
+        echo 500 Action%20not%20recognized
     elif [ -z "$group" ]; then
-        echo 400 Group%20name%20not%20provided
+        echo 500 Group%20name%20not%20provided
     else
         user_list=$(getent group "$group")
         if [ "$?" -ne "2" ]; then


### PR DESCRIPTION
This pull request enable postfix to create distribution lists based on system groups:

* create a service that return the users list of a group using the postfix tcp_map protocol.
* Add a systemd socket for activate the service.
* Add a prop `DynamicGroupAlias` for enable/disable the feature.