### PR TITLE
server: use proxymap for local group resolution

### DIFF
--- a/server/etc/e-smith/templates/etc/postfix/main.cf/20virtual_domains
+++ b/server/etc/e-smith/templates/etc/postfix/main.cf/20virtual_domains
@@ -28,7 +28,7 @@ virtual_mailbox_maps = proxy:unix:passwd.byname {
     }
     return '';
 }
-virtual_alias_maps = hash:/etc/postfix/virtual { ($postfix{DynamicGroupAlias} || '') eq 'enabled' ? 'tcp:127.0.0.1:14444' : '' }
+virtual_alias_maps = hash:/etc/postfix/virtual { ($postfix{DynamicGroupAlias} || '') eq 'enabled' ? 'proxy:tcp:127.0.0.1:14444' : '' }
 
 # Message delivery transport that the local(8)
 # delivery agent should use for mailbox delivery:


### PR DESCRIPTION
Use proxymap for reduce invocations of postfix-get-group service,
avoiding spamming in the system log.

see also: https://community.nethserver.org/t/sending-an-email-to-ldap-ad-group-mail-alias-is-not-a-solution/12104/45

NethServer/dev#5725