### PR TITLE
server: add support for space in local groups name

### DIFF
--- a/server/usr/libexec/nethserver/postfix-get-group
+++ b/server/usr/libexec/nethserver/postfix-get-group
@@ -30,6 +30,7 @@ do
     elif [ -z "$group" ]; then
         echo 500 Group%20name%20not%20provided
     else
+	group=$(echo -n "$group" | sed -e 's/"//g; s/%20/ /g')
         user_list=$(getent group "$group")
         if [ "$?" -ne "2" ]; then
             msg=$(echo  -n "$user_list" |  cut -d ':' -f 4)


### PR DESCRIPTION
Add intial support for quoted string format of email address's local
part, only decode of space char (%20) are implemented.
NethServer/dev#5725