### PR TITLE
Disabled groups alias list

### DIFF
--- a/createlinks-server
+++ b/createlinks-server
@@ -39,6 +39,7 @@ my @saveTemplates = qw(
     /etc/postfix/transport
     /etc/postfix/virtual
     /etc/postfix/internal_access
+    /etc/postfix/disabled_groups
     /etc/postfix/recipient_bcc
     /etc/postfix/login_maps.pcre
     /etc/postfix/login_maps

--- a/createlinks-server
+++ b/createlinks-server
@@ -223,6 +223,7 @@ event_templates('mailbox-save', qw(
       /etc/postfix/virtual
       /etc/dovecot/quota.passwd
       /etc/postfix/internal_access
+      /etc/postfix/disabled_groups
 ));
 
 event_actions('mailbox-save', qw(

--- a/createlinks-server
+++ b/createlinks-server
@@ -233,6 +233,7 @@ event_actions('mailbox-save', qw(
 
 event_services('mailbox-save', qw(
   dovecot reload
+  postfix reload
 ));
 
 #

--- a/server/etc/e-smith/templates/etc/postfix/disabled_groups/10base
+++ b/server/etc/e-smith/templates/etc/postfix/disabled_groups/10base
@@ -1,0 +1,12 @@
+#
+# 10base -- list of disabled group aliases, ignored by postfix-get-group
+#
+{
+    use esmith::ConfigDB;
+    foreach (esmith::ConfigDB->open_ro('accounts')->get_all_by_prop('type' => 'group')) {
+        my $groupName = $_->key();
+        if(($_->prop('MailStatus') || '') eq 'disabled') {
+            $OUT .= $groupName . "\n";
+        }
+    }
+}

--- a/server/usr/libexec/nethserver/postfix-get-group
+++ b/server/usr/libexec/nethserver/postfix-get-group
@@ -30,7 +30,7 @@ do
     elif [ -z "$group" ]; then
         echo 500 Group%20name%20not%20provided
     else
-	group=$(echo -n "$group" | sed -e 's/"//g; s/%20/ /g')
+        group=$(echo -n "$group" | sed -e 's/"//g; s/%20/ /g')
         group_disabled=$(grep -x -F "${group}" /etc/postfix/disabled_groups)
         user_list=$(getent group "$group")
         if [ "$?" -ne "2" ] && [ "${group_disabled}" == "" ]; then

--- a/server/usr/libexec/nethserver/postfix-get-group
+++ b/server/usr/libexec/nethserver/postfix-get-group
@@ -31,8 +31,9 @@ do
         echo 500 Group%20name%20not%20provided
     else
 	group=$(echo -n "$group" | sed -e 's/"//g; s/%20/ /g')
+        group_disabled=$(grep -x -F "${group}" /etc/postfix/disabled_groups)
         user_list=$(getent group "$group")
-        if [ "$?" -ne "2" ]; then
+        if [ "$?" -ne "2" ] && [ "${group_disabled}" == "" ]; then
             msg=$(echo  -n "$user_list" |  cut -d ':' -f 4)
             echo 200 "${msg:0:4091}"
         else


### PR DESCRIPTION
- ignore a group alias if listed in /etc/postfix/disabled_groups
- clear Postfix address verification cache when group setup changes

This PR works with the new DB record type `group` introduced by #107 

NethServer/dev#5725