### PR TITLE
Moved bayes expiry to local.d/statistic.conf

### DIFF
--- a/filter/etc/rspamd/local.d/classifier-bayes.conf
+++ b/filter/etc/rspamd/local.d/classifier-bayes.conf
@@ -1,7 +1,0 @@
-#
-# This file will be overwritten by the next rpm update
-# use /etc/rspamd/override.d/file.conf' - to override the defaults
-#
-
-new_schema = true;
-expire = 8640000;

--- a/filter/etc/rspamd/local.d/statistic.conf
+++ b/filter/etc/rspamd/local.d/statistic.conf
@@ -60,5 +60,12 @@ return function(task, is_spam, is_unlearn)
     return true
 end
 EOD
+
+
+# bayes expiry, see https://rspamd.com/doc/modules/bayes_expiry.html
+# moved here due to conflicting files, see GH5741
+new_schema = true;
+expire = 8640000;
+
 }
 

--- a/nethserver-mail.spec
+++ b/nethserver-mail.spec
@@ -37,7 +37,7 @@ Summary: Enforces anti-spam and anti-virus checks on any message entering the ma
 BuildArch: noarch
 Requires: %{name}-common >= %{version}, nethserver-antivirus
 Requires: nethserver-dnsmasq, nethserver-unbound
-Requires: rspamd >= 1.8.1
+Requires: rspamd >= 1.9.1
 Requires: redis
 Requires: zstd
 Requires: mod_authnz_pam


### PR DESCRIPTION
Due to the upgrade of rspamd 1.9.1, we need to move the bayes expiry settings to` local.d/statistic.conf`

https://github.com/NethServer/dev/issues/5741