### PR TITLE
api. Fix smarthost DB initialization

### DIFF
--- a/nethserver-mail.spec
+++ b/nethserver-mail.spec
@@ -15,7 +15,7 @@ Mail services configuration packages, based on Postfix, Dovecot, Rspamd
 %package common
 Summary: Common configuration for mail packages
 BuildArch: noarch
-Requires: nethserver-base
+Requires: %{name}-smarthost >= %{version}
 Obsoletes: nethserver-mail2-common < %{obsversion}
 Provides: nethserver-mail2-common = %{version}
 BuildRequires: nethserver-devtools


### PR DESCRIPTION
The latest smarthost package must be installed to not break the
nethserver-mail/send/read API

```text
Can't call method "get_all" on an undefined value at /usr/libexec/nethserver/api/nethserver-mail/send/read line 38, <STDIN> line 1.
```

NethServer/dev#5743 