### PR TITLE
Send SMTP AUTH probe with swaks

### DIFF
--- a/api/send/read
+++ b/api/send/read
@@ -73,26 +73,31 @@ if ($cmd eq 'list') {
     $ret->{'AccessBypassList'} = [split(/,/, $cdb->get_prop('postfix','AccessBypassList'))];
 } elsif ($cmd eq 'check-credentials') {
 
-    my $url = "smtp://";
-    my $command = "curl --connect-timeout 3 -k -Ss --mail-rcpt 'root' -T /dev/null ";
+    my @argv = qw(-S 3 -a -q AUTH);
+
     if ($input->{'TlsStatus'} eq 'enabled') {
-        $command .= " --ssl ";
+        push @argv, '--tls';
+    } else {
+        push @argv, '--tls-optional-strict';
     }
 
     if ($input->{'Username'} && $input->{'Password'}) {
-        $command .= "-u \"".$input->{'Username'}.":".$input->{'Password'}."\"";
+        push @argv, '-au', $input->{'Username'}, '-ap', $input->{'Password'};
     }
 
-    $url .= $input->{'Host'}.":".$input->{'Port'};
+    push @argv, '--server', $input->{'Host'}, '--port', $input->{'Port'};
 
-    my $out = `$command $url 2>&1`;
-    if ($? > 0) {
-        chomp $out;
-        $out =~ s/curl: \(\d+\)\s+//;
-        error("GenericError",$out);
-    } else {
+    system(qw(/usr/bin/swaks), @argv);
+    if ($? == 0) {
         success();
+    } elsif($?>>8 == 28) {
+        error("AuthenticationError", "AUTH error");
+    } elsif($?>>8 == 2) {
+        error("ConnectionError", "Connection error");
+    } else {
+        error("GenericError", "Check the swaks command exit code: " . ($?>>8));
     }
+
 } else {
     error();
 }

--- a/nethserver-mail.spec
+++ b/nethserver-mail.spec
@@ -22,6 +22,7 @@ BuildRequires: nethserver-devtools
 Requires: nethserver-cockpit-lib
 Requires: discount
 Requires: bind-utils
+Requires: swaks
 %description common
 Common configuration for mail packages, based on Postfix.
 


### PR DESCRIPTION
The `curl` command has a bad side-effect: it actually sends a (empty) message.

This PR runs the SMTP AUTH validation with `swaks` http://www.jetmore.org/john/code/swaks/

A `swaks` RPM is available from EPEL 7.

NethServer/dev#5743