### PR TITLE
api public mailboxes: remove delete ACL

### DIFF
--- a/api/lib/mail_functions.pl
+++ b/api/lib/mail_functions.pl
@@ -95,6 +95,48 @@ sub get_account_object
     }
 }
 
+sub get_folder_acls
+{
+    my $name = shift;
+    my @read_r = sort ("lookup", "read", "write-seen");
+    my @read_write_r = sort (@read_r, ("insert", "create", "write", "write-deleted"));
+    my @full_r = sort (@read_write_r, ("expunge", "admin", "post"));
+
+    my $read = join(" ", @read_r);
+    my $read_write = join(" ", @read_write_r);
+    my $full = join(" ", @full_r);
+
+    my @acls = `/usr/bin/doveadm -f tab acl get -u vmail '$name' 2>/dev/null`;
+    shift @acls;
+
+    my @ret = ();
+
+    foreach (@acls) {
+        my $info = {};
+        chomp;
+        ($info->{'id'}, $info->{'global'}, $info->{'rawrights'}) = split("\t",$_);
+        ($info->{'type'}, $info->{'name'}) = split("=", $info->{'id'});
+        $info->{'displayname'} = $info->{'name'};
+        $info->{'displayname'} =~ s/(\@.*)$//;
+        my @tmp = sort split(/\s/, $info->{'rawrights'});
+        my $rights_str = join(" ", @tmp);
+        if ($rights_str eq $full) {
+            $info->{'right'} = "full";
+        } elsif ($rights_str eq $read_write) {
+            $info->{'right'} = "read-write";
+        } elsif ($rights_str eq $read) {
+            $info->{'right'} = "read";
+        } else {
+            $info->{'right'} = "custom";
+        }
+
+        push(@ret, $info);
+    }
+
+    return \@ret;
+}
+
+
 sub get_public_mailbox_event_args
 {
     my $input = shift;

--- a/api/lib/mail_functions.pl
+++ b/api/lib/mail_functions.pl
@@ -172,6 +172,18 @@ sub get_public_mailbox_event_args
         push(@args, $perms);
     }
 
+    # clear removed ACLs
+    my $current_acls = get_folder_acls($input->{'name'});
+    foreach my $cur (@$current_acls) {
+        my $to_be_removed = 1;
+        foreach my $new (@$acls) {
+            $to_be_removed  = 0 if ($cur->{'id'} eq $new->{'type'}."=".$new->{'name'});
+        }
+        if ($to_be_removed) {
+            push(@args, ($cur->{'id'}, "CLEAR"));
+        }
+    }
+
     return \@args;
 }
 

--- a/api/mailbox/read
+++ b/api/mailbox/read
@@ -28,47 +28,6 @@ use JSON;
 require '/usr/libexec/nethserver/api/lib/helper_functions.pl';
 require '/usr/libexec/nethserver/api/nethserver-mail/lib/mail_functions.pl';
 
-sub get_folder_acls
-{
-    my $name = shift;
-    my @read_r = sort ("lookup", "read", "write-seen");
-    my @read_write_r = sort (@read_r, ("insert", "create", "write", "write-deleted"));
-    my @full_r = sort (@read_write_r, ("expunge", "admin", "post"));
-
-    my $read = join(" ", @read_r);
-    my $read_write = join(" ", @read_write_r);
-    my $full = join(" ", @full_r);
-
-    my @acls = `/usr/bin/doveadm -f tab acl get -u vmail '$name' 2>/dev/null`;
-    shift @acls;
-
-    my @ret = ();
-
-    foreach (@acls) {
-        my $info = {};
-        chomp;
-        ($info->{'id'}, $info->{'global'}, $info->{'rawrights'}) = split("\t",$_);
-        ($info->{'type'}, $info->{'name'}) = split("=", $info->{'id'});
-        $info->{'displayname'} = $info->{'name'};
-        $info->{'displayname'} =~ s/(\@.*)$//;
-        my @tmp = sort split(/\s/, $info->{'rawrights'});
-        my $rights_str = join(" ", @tmp);
-        if ($rights_str eq $full) {
-            $info->{'right'} = "full";
-        } elsif ($rights_str eq $read_write) {
-            $info->{'right'} = "read-write";
-        } elsif ($rights_str eq $read) {
-            $info->{'right'} = "read";
-        } else {
-            $info->{'right'} = "custom";
-        }
-
-        push(@ret, $info);
-    }
-
-    return \@ret;
-}
-
 sub list_public_folders
 {
     my $expand = shift;


### PR DESCRIPTION
Previously, the API didn't manage to remove the ACLs marked as deleted
from the UI.

Original code for NethGUI: https://github.com/NethServer/nethserver-mail/blob/517b89baaea06a36299783708b3dfb6091d9cf4f/server/usr/share/nethesis/NethServer/Module/MailAccount/SharedMailbox/Edit.php#L99