### PR TITLE
Move to junk only if the headers match

### DIFF
--- a/getmail/etc/e-smith/templates/var/lib/nethserver/sieve-scripts/before.sieve/30getmailFilter
+++ b/getmail/etc/e-smith/templates/var/lib/nethserver/sieve-scripts/before.sieve/30getmailFilter
@@ -21,14 +21,4 @@ if header :regex ["X-Spam-Action"] ["rewrite subject"] {
     addheader :last "subject" "$rspamd{SpamSubjectPrefixString} \${subjwas}";
 }
 ) if (($rspamd{SpamSubjectPrefixString}) && ($rspamd{SpamSubjectPrefixStatus} eq 'enabled'));
-
-
-$OUT .= qq(
-
-# --  Move rspamd tag to junk
-if header :contains "X-Spam" "YES" {
-    fileinto :create "$dovecot{SpamFolder}";
-    stop;
-}
-) if ( $dovecot{SpamFolder});
 }

--- a/server/etc/e-smith/templates/var/lib/nethserver/sieve-scripts/before.sieve/20junkmail
+++ b/server/etc/e-smith/templates/var/lib/nethserver/sieve-scripts/before.sieve/20junkmail
@@ -14,11 +14,11 @@ if header :contains "X-Spam-Flag" "YES" {
 );
 
 $OUT .= qq(
-# -- enabled (move spam subject to junkmail folder)
-if header :contains "subject" "$rspamd{SpamSubjectPrefixString}" {
-   fileinto :create "$dovecot{SpamFolder}";
-   stop;
-}
-) if (($rspamd{SpamSubjectPrefixString}) && ($rspamd{SpamSubjectPrefixStatus} eq 'enabled'));
 
+# --  Move rspamd tag to junk
+if header :contains "X-Spam" "YES" {
+    fileinto :create "$dovecot{SpamFolder}";
+    stop;
+}
+);
 }

--- a/server/etc/e-smith/templates/var/lib/nethserver/sieve-scripts/before.sieve/40junkmail
+++ b/server/etc/e-smith/templates/var/lib/nethserver/sieve-scripts/before.sieve/40junkmail
@@ -1,6 +1,6 @@
 
 #
-# 10junkmail 
+# 40junkmail 
 #
 {
 return '# -- disabled (Spam is delivered to INBOX)' if ( ! $dovecot{SpamFolder});


### PR DESCRIPTION
nethserver-mail-getmail has for dependency nethserver-mail-server, we could move the fragment to the nethserver-mail-server, but we need to put the sieve filter of server after the sieve filter of getmail (else the subject won't be rewritten by the sieve filter, it could be moved first to junk)

We only look after the headers X-Spam-Flag or X-Spam to move the email to junk

https://github.com/NethServer/dev/issues/5771