### PR TITLE
Do not soft reject for authenticated users

### DIFF
--- a/createlinks-filter
+++ b/createlinks-filter
@@ -33,6 +33,7 @@ my @templates = qw(
     /etc/rspamd/local.d/greylist.conf
     /etc/rspamd/local.d/multimap.conf
     /etc/rspamd/override.d/metrics.conf
+    /etc/rspamd/local.d/settings.conf
     /etc/rspamd/rspamd.conf
     /etc/rspamd/rspamd.conf.override
     /etc/rspamd/whitelist_ip.map

--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/antivirus.conf/10base
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/antivirus.conf/10base
@@ -29,8 +29,8 @@ clamav \{
 
   # Timeout and retransmits increased in case of clamav is reloading its database
   # It takes a lot of time (25 to 60 seconds), after rspamd answers a temporally failure
-  timeout = 13.0;
-  retransmits = 4;
+  #timeout = 5;
+  #retransmits = 2;
 
   # servers to query (if port is unspecified, scanner-specific default is used)
   # can be specified multiple times to pool servers

--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/settings.conf/10AuthenticatedUser
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/settings.conf/10AuthenticatedUser
@@ -1,0 +1,9 @@
+
+#Do not soft reject if clamav is not reachable
+authenticated \{
+        priority = high;
+        authenticated = yes;
+        apply \{
+                symbols_disabled = ["FORCE_ACTION_CLAM_VIRUS_FAIL"];
+        \}
+\}


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/5773

I need a template due to nethserver-mail-quarantine which use also local.d/settings.conf

the symbol `CLAM_VIRUS_FAIL(0.00){failed to scan and retransmits exceed;}` is still added but the force action we made on this symbol is deactivated for authenticated users

check maillog : https://gist.github.com/stephdl/de6fc5fcfaffac48d654d26b44ad151f
