### PR TITLE
Minor cockpit fixes

### DIFF
--- a/api/lib/mail_functions.pl
+++ b/api/lib/mail_functions.pl
@@ -70,10 +70,11 @@ sub get_account_object
     my $users = shift;
     my $groups = shift;
     my $adb = shift;
+    my $ddb = shift;
     my $ret;
 
-    my @tmp = split(/\@/,$account);
-    my $wildcard_name = $tmp[0]."@";
+    my ($user, $domain)= split(/\@/,$account);
+    my $wildcard_name = $user.'@';
     if ($account eq 'root') {
         return {'name' => 'root', 'type' => 'builtin'};
     } elsif ($users->{$account}) {
@@ -88,7 +89,7 @@ sub get_account_object
     } elsif ($adb->get($account)) {
         $account =~ s/(\@.*)$//;
         return {'name' => $account, 'type' => $adb->get_prop($account, 'type')};
-    } elsif ($adb->get($wildcard_name)) {
+    } elsif ($adb->get($wildcard_name) && defined($ddb->get($domain))) { # match only if the domain is handled by the server itself
         return {'name' => $wildcard_name, 'type' => $adb->get_prop($wildcard_name, 'type')}
     } else {
         return {'name' => $account, 'type' => 'external'};

--- a/api/pseudonym/read
+++ b/api/pseudonym/read
@@ -82,7 +82,7 @@ if ($cmd eq 'list') {
         }
          
         foreach my $account (split(',', $props{'Account'})) {
-            my $obj = get_account_object($account, $users, $groups, $adb);
+            my $obj = get_account_object($account, $users, $groups, $adb, $ddb);
             push(@accounts, $obj);
         }
         $props{'Account'} = \@accounts;

--- a/ui/src/views/Addresses.vue
+++ b/ui/src/views/Addresses.vue
@@ -230,7 +230,6 @@
                     :options="autoOptions"
                     :onInputChange="filterSrcAuto"
                     :onItemSelected="selectSrcAuto"
-                    :required="!newAddress.isEdit"
                   >
                     <div slot="item" slot-scope="props" class="single-item">
                       <span>


### PR DESCRIPTION
-  mail alias creation validator: an external address alone is not allowed
- mail alias edit: an external address is displayed without domain suffix