### PR TITLE
Reject forbidden MIME with SMTP message

### DIFF
--- a/createlinks-filter
+++ b/createlinks-filter
@@ -32,6 +32,7 @@ my @templates = qw(
     /etc/rspamd/local.d/antivirus.conf
     /etc/rspamd/local.d/greylist.conf
     /etc/rspamd/local.d/multimap.conf
+    /etc/rspamd/local.d/mime_types.conf
     /etc/rspamd/override.d/metrics.conf
     /etc/rspamd/local.d/settings.conf
     /etc/rspamd/rspamd.conf

--- a/filter/etc/e-smith/templates/etc/rspamd/forbidden_file_extension.map/10base
+++ b/filter/etc/e-smith/templates/etc/rspamd/forbidden_file_extension.map/10base
@@ -7,7 +7,7 @@ return unless ($rspamd{BlockAttachmentStatus} eq 'enabled');
 
 # Known classes:
 my %extClasses = (
-'Exec' => [qw(exe exe-ms vbe vbs wsc wsf wsh msc msi msp mst pif scr sct bat cmd com cpl dll jse inf)],
+'Exec' => [qw(exe exe-ms vbe vbs wsc wsf wsh msc msi msp mst pif scr sct bat cmd com cpl dll jse inf js jar)],
 'Arch' => [qw(zip 7z rar tar gz cab bz2)],
 );
 

--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/mime_types.conf/10base
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/mime_types.conf/10base
@@ -1,0 +1,65 @@
+{
+#
+# block attachment following file extensions
+#
+return unless ($rspamd{BlockAttachmentStatus} eq 'enabled');
+
+
+# Known classes:
+my %extClasses = (
+'Exec' => [qw(exe exe-ms vbe vbs wsc wsf wsh msc msi msp mst pif scr sct bat cmd com cpl dll jse inf js jar)],
+'Arch' => [qw(zip 7z rar tar gz cab bz2)],
+);
+
+if(defined $rspamd{BlockAttachmentClassList}) {
+    foreach $class (split(',', ($rspamd{BlockAttachmentClassList}))) {
+        if(($class eq 'Exec') && defined $extClasses{'Exec'}) {
+            push @banned_extensions, @{$extClasses{'Exec'}};
+        }
+        if(($class eq 'Arch') && defined $extClasses{'Arch'}) {
+            push @banned_archives, @{$extClasses{'Arch'}};
+        }
+    }
+}
+
+# Custom list:
+if($rspamd{BlockAttachmentCustomStatus} eq 'enabled'
+    && defined $rspamd{BlockAttachmentCustomList}) {
+    foreach $extension (split(',', ($rspamd{BlockAttachmentCustomList}))) {
+        # trim whitespace:
+        $extension =~ s/\s+//;
+        push @banned_extensions, $extension;
+    }
+}
+
+if (@banned_extensions) {
+    # Here we reject with a 1 multiplicator the bad extensions and archives
+    # a force action will reject and add the smtp message rejection
+
+    # meta array, we don't want to push arch extension to bad_archive_extensions
+    push @banned_extensionsArchives,(@banned_extensions,@banned_archives);
+
+    $OUT .= q(
+# Extensions and archives that are treated as 'bad'
+# Number is score multiply factor
+bad_extensions = {
+);
+    foreach $lines (@banned_extensionsArchives){
+        $OUT .= "$lines = 1,\n";
+    }
+
+    $OUT .='};'."\n";
+    $OUT.= q(
+# Extensions that cannot be inside archives
+bad_archive_extensions = {
+);
+    foreach $lines (@banned_extensions){
+        $OUT .= "$lines = 1,\n";
+    }
+
+    $OUT .='};'."\n";
+}
+
+# return empty if arrays undefined
+'';
+}

--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/multimap.conf/10base
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/multimap.conf/10base
@@ -52,7 +52,7 @@ FROM_BLACKLIST {
     filter = "email:addr";
     symbol = "FROM_BLACKLIST";
     description = "Refused list of FROM email address";
-    message = "Rejected due to refused list of FROM email address";
+    message = "Sender address rejected";
 }
 
 #blacklist the domains of senders
@@ -65,7 +65,7 @@ FROM_DOMAINS_BLACKLIST {
     description = "Refused list of FROM domains";
     symbol = "FROM_DOMAINS_BLACKLIST";
     score = 300;
-    message = "Rejected due to refused list of FROM domains";
+    message = "Sender domain address rejected";
 }
 
 #whitelist the domain of recipients
@@ -110,7 +110,7 @@ $OUT .= << 'EOF'
     action = "reject";
     symbol = "FORBIDDEN_FILE_EXTENSION";
     description = "List of forbidden file extensions";
-    message = "Rejected due to forbidden extension in attached file";
+    message = "Forbidden attachment name extension";
 }
 EOF
 }

--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/multimap.conf/10base
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/multimap.conf/10base
@@ -52,6 +52,7 @@ FROM_BLACKLIST {
     filter = "email:addr";
     symbol = "FROM_BLACKLIST";
     description = "Refused list of FROM email address";
+    message = "Rejected due to refused list of FROM email address";
 }
 
 #blacklist the domains of senders
@@ -64,6 +65,7 @@ FROM_DOMAINS_BLACKLIST {
     description = "Refused list of FROM domains";
     symbol = "FROM_DOMAINS_BLACKLIST";
     score = 300;
+    message = "Rejected due to refused list of FROM domains";
 }
 
 #whitelist the domain of recipients
@@ -108,6 +110,7 @@ $OUT .= << 'EOF'
     action = "reject";
     symbol = "FORBIDDEN_FILE_EXTENSION";
     description = "List of forbidden file extensions";
+    message = "Rejected due to forbidden extension in attached file";
 }
 EOF
 }

--- a/filter/etc/rspamd/local.d/force_actions.conf
+++ b/filter/etc/rspamd/local.d/force_actions.conf
@@ -11,7 +11,7 @@ rules {
     }
     MIME_BAD_EXTENSION {
         action = "reject";
-        message = "Rejected due to forbidden MIME in attached file";
+        message = "Forbidden attachment content type";
         expression = "MIME_BAD_EXTENSION";
     }
 }

--- a/filter/etc/rspamd/local.d/force_actions.conf
+++ b/filter/etc/rspamd/local.d/force_actions.conf
@@ -9,4 +9,9 @@ rules {
         message = "Cannot validate the message now. Try again later";
         expression = "CLAM_VIRUS_FAIL";
     }
+    MIME_BAD_EXTENSION {
+        action = "reject";
+        message = "Rejected due to forbidden MIME in attached file";
+        expression = "MIME_BAD_EXTENSION";
+    }
 }


### PR DESCRIPTION
When we decide to reject Exec or Arch, we add a new setting to put a 20x multiplicator to reject MIME detected

As a side note we have a lot more MIME that we could detect, for example I added `js` and `jar` for the to the bad extensions

please check the code at https://github.com/rspamd/rspamd/blob/master/src/plugins/lua/mime_types.lua

The custom extension could not be added here, we cannot be sure that it could not break rspamd.


When I put a not desired MIME xlsx inside an archive now it is rejected -> https://gist.github.com/812e6c7d35e90e09a6bd72eb2ea358f1

https://github.com/NethServer/dev/issues/5779
