### PR TITLE
Restart clamd rspamd instance on nethserver-antivirus-update

### DIFF
--- a/api/filter/update
+++ b/api/filter/update
@@ -46,4 +46,5 @@ foreach (keys %$props) {
 
     $db->set_prop('rspamd', $_, $value);
 }
+$db->set_prop('clamd@rspamd', 'VirusCheckStatus', $props->{'VirusCheckStatus'});
 system("/sbin/e-smith/signal-event -j nethserver-mail-filter-save");

--- a/createlinks-filter
+++ b/createlinks-filter
@@ -82,6 +82,7 @@ event_services($event, qw(
     rspamd reload
     postfix reload
     httpd-admin reload
+    clamd@rspamd restart
 ));
 
 #

--- a/createlinks-filter
+++ b/createlinks-filter
@@ -116,3 +116,10 @@ event_services('trusted-networks-modify', qw(
     rspamd reload
 ));
 
+
+#
+# nethserver-antivirus-update event
+#
+event_services('nethserver-antivirus-update', qw(
+    clamd@rspamd restart
+));

--- a/createlinks-filter
+++ b/createlinks-filter
@@ -32,6 +32,7 @@ my @templates = qw(
     /etc/rspamd/local.d/antivirus.conf
     /etc/rspamd/local.d/greylist.conf
     /etc/rspamd/local.d/multimap.conf
+    /etc/rspamd/local.d/force_actions.conf
     /etc/rspamd/override.d/metrics.conf
     /etc/rspamd/local.d/settings.conf
     /etc/rspamd/rspamd.conf

--- a/filter/etc/e-smith/db/configuration/defaults/clamd@rspamd/status
+++ b/filter/etc/e-smith/db/configuration/defaults/clamd@rspamd/status
@@ -1,0 +1,1 @@
+enabled

--- a/filter/etc/e-smith/db/configuration/defaults/clamd@rspamd/type
+++ b/filter/etc/e-smith/db/configuration/defaults/clamd@rspamd/type
@@ -1,0 +1,1 @@
+service

--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/force_actions.conf/10base
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/force_actions.conf/10base
@@ -1,0 +1,19 @@
+#
+# This file will be overwritten by the next rpm update
+# use /etc/rspamd/override.d/file.conf' - to override the defaults
+#
+{
+    $vc = $rspamd{'VirusCheckStatus'} || 'enabled';
+ 
+    if ($vc eq 'enabled') {
+        $OUT .= 'rules {
+    CLAM_VIRUS_FAIL { 
+        action = "soft reject";
+        message = "Cannot validate the message now. Try again later";
+        expression = "CLAM_VIRUS_FAIL";
+    }
+}';
+    } else {
+        $OUT .= "# VirusCheckStatus is disabled\n";
+    }
+}

--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/settings.conf/10AuthenticatedUser
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/settings.conf/10AuthenticatedUser
@@ -1,9 +1,16 @@
+{
+    $vc = $rspamd{'VirusCheckStatus'} || 'enabled';
 
-#Do not soft reject if clamav is not reachable
-authenticated \{
+    if ($vc eq 'enabled') {
+    $OUT .= "#Do not soft reject if clamav is not reachable\n";
+    $OUT .= 'authenticated {
         priority = high;
         authenticated = yes;
-        apply \{
+        apply {
                 symbols_disabled = ["FORCE_ACTION_CLAM_VIRUS_FAIL"];
-        \}
-\}
+        }
+}';
+    } else {
+        $OUT .= "# VirusCheckStatus is disabled";
+    }
+}

--- a/filter/usr/lib/systemd/system/rspamd.service.d/nethserver.conf
+++ b/filter/usr/lib/systemd/system/rspamd.service.d/nethserver.conf
@@ -1,6 +1,6 @@
 # start clamd and redis-rspamd by rspamd.service
 [Unit]
-Wants=clamd@rspamd.service
+After=clamd@rspamd.service
 Wants=redis-rspamd.service
 After=redis-rspamd.service
 


### PR DESCRIPTION
- clamd@rspamd instance is now restarted on every nethserver-mail-filter-save event
- clamd@rspamd is no more a required service for rspamd
- if antivirus check is disabled, clamd@rspamd is stopped

See also NethServer/nethserver-antivirus#4

NethServer/dev#5803