### PR TITLE
getmail: log errors to syslog

### DIFF
--- a/getmail/etc/e-smith/templates/etc/cron.d/getmail/10base
+++ b/getmail/etc/e-smith/templates/etc/cron.d/getmail/10base
@@ -9,7 +9,7 @@
         next if ($status eq 'disabled');
         my $cfg = $OUT_DIR."/".$account->key.".cfg";
         my $time = $account->prop('Time') || '30';
-        my $cmd = "/usr/bin/flock -n -E 0 $cfg -c \"/usr/bin/getmail --getmaildir /var/lib/getmail/ --rcfile $cfg --quiet\"";
+        my $cmd = "/usr/bin/flock -n -E 0 $cfg -c \"/usr/bin/getmail --getmaildir /var/lib/getmail/ --rcfile $cfg --quiet 2>&1 | logger -p mail.err -t getmail\"";
         $time = ($time >= 60) ? 59 : $time;
         
         $OUT .= "*/$time * * * * root $cmd \n";


### PR DESCRIPTION
getmail connection errors go to syslog (and then to maillog) instead of sending a mail to root
syadmin is used to look for errors in maillog, not in root mail archive
Moreover, getmail already logs some of its messages to maillog, this
pull request will unify behavior

NethServer/dev#5815