### PR TITLE
Shared mailbox api: fix creation

### DIFF
--- a/api/mailbox/create
+++ b/api/mailbox/create
@@ -43,6 +43,9 @@ if (!$record) {
     $db->new_record($wildcard, {'type' => 'pseudonym', 'Account' => "vmail+".$input->{'name'}, "Access" => "public", "Description" => "Created automatically for public folder ".$input->{'name'}});
 }
 
+system(("/sbin/e-smith/signal-event", "pseudonym-create", "vmail+".$input->{'name'}));
+$exitCode = $? >> 8;
+
 my $eventArgs = get_public_mailbox_event_args($input);
 
 esmith::event::set_json_log(1);
@@ -58,7 +61,7 @@ if(esmith::event::event_signal($eventName, @$eventArgs)) {
             'event_args' => $eventArgs,
         }
     };
-    $exitCode = 1;
+    $exitCode = $exitCode + 1;
 }
 
 print encode_json($ret);

--- a/api/mailbox/validate
+++ b/api/mailbox/validate
@@ -54,10 +54,8 @@ function validate_acls($v, $data) {
             }
         }
 
-        foreach ($acl['rights'] as $r) {
-            if (!in_array($r, $rights)) {
-                $v->addValidationError('rights', 'invalid_rights');
-            }
+        if (!in_array($acl['right'], $rights)) {
+            $v->addValidationError('rights', 'invalid_rights');
         }
     }
 }


### PR DESCRIPTION
- invoke pseudonym-create event
- correctly validate acl rights

NethServer/dev#5834