### PR TITLE
api connectors: correctly handle username with '@'

### DIFF
--- a/api/connectors/read
+++ b/api/connectors/read
@@ -24,12 +24,11 @@ use strict;
 use warnings;
 use esmith::ConfigDB;
 use JSON;
+use NethServer::ApiTools;
 
-require '/usr/libexec/nethserver/api/lib/helper_functions.pl';
 require '/usr/libexec/nethserver/api/nethserver-mail/lib/mail_functions.pl';
-use IPC::Run 'run';
 
-my $input = readInput();
+my $input = NethServer::ApiTools::readInput();
 my $cmd = $input->{'action'};
 
 my $ret = {};
@@ -69,23 +68,22 @@ if ($cmd eq 'list') {
     } elsif ($input->{'Retriever'} eq 'SimpleIMAPSSLRetriever') {
         $url .= "imaps";
     } else {
-        error();
+        NethServer::ApiTools::error();
     }
 
-
-    #$url .= "://".$input->{'Username'}.":".$input->{'Password'}."@".$input->{'Server'};
     $url .= "://".$input->{'Server'};
 
-    my $success = run [ "curl", "--connect-timeout", "2", "-Ss", "-k", "--user", $input->{'Username'}.":".$input->{'Password'}, $url ], ">", \my $out, '2>&1';
-    if ($success) {
-        success();
-    } else {
+    my $out = NethServer::ApiTools::exec_slurp("curl", "--connect-timeout", "2", "-s", "-k", "--user", $input->{'Username'}.":".$input->{'Password'}, $url);
+
+    if ($? > 0){
         chomp $out;
         $out =~ s/curl: \(\d+\)\s+//;
-        error("GenericError",$out);
+        NethServer::ApiTools::error("GenericError",$out);
+    } else {
+        NethServer::ApiTools::success();
     }
 } else {
-    error();
+    NethServer::ApiTools::error();
 }
 
 print encode_json($ret);

--- a/api/connectors/read
+++ b/api/connectors/read
@@ -27,6 +27,7 @@ use JSON;
 
 require '/usr/libexec/nethserver/api/lib/helper_functions.pl';
 require '/usr/libexec/nethserver/api/nethserver-mail/lib/mail_functions.pl';
+use IPC::Run 'run';
 
 my $input = readInput();
 my $cmd = $input->{'action'};
@@ -71,15 +72,17 @@ if ($cmd eq 'list') {
         error();
     }
 
-    $url .= "://".$input->{'Username'}.":".$input->{'Password'}."@".$input->{'Server'};
 
-    my $out = `curl --connect-timeout 2 -Ss -k $url 2>&1`;
-    if ($? > 0) {
+    #$url .= "://".$input->{'Username'}.":".$input->{'Password'}."@".$input->{'Server'};
+    $url .= "://".$input->{'Server'};
+
+    my $success = run [ "curl", "--connect-timeout", "2", "-Ss", "-k", "--user", $input->{'Username'}.":".$input->{'Password'}, $url ], ">", \my $out, '2>&1';
+    if ($success) {
+        success();
+    } else {
         chomp $out;
         $out =~ s/curl: \(\d+\)\s+//;
         error("GenericError",$out);
-    } else {
-        success();
     }
 } else {
     error();

--- a/nethserver-mail.spec
+++ b/nethserver-mail.spec
@@ -23,7 +23,6 @@ Requires: nethserver-cockpit-lib
 Requires: discount
 Requires: bind-utils
 Requires: swaks
-Requires: perl-IPC-Run
 %description common
 Common configuration for mail packages, based on Postfix.
 

--- a/nethserver-mail.spec
+++ b/nethserver-mail.spec
@@ -23,6 +23,7 @@ Requires: nethserver-cockpit-lib
 Requires: discount
 Requires: bind-utils
 Requires: swaks
+Requires: perl-IPC-Run
 %description common
 Common configuration for mail packages, based on Postfix.
 


### PR DESCRIPTION
Do not fail with error like:
curl: (6) Could not resolve host: domain.org:mypass@192.168.5.1.1; Unknown error

Add some perl magic using IPC::Run to protect the input from shell
injection.

NethServer/dev#5873