### PR TITLE
Upgrade default Olefy listen port

### DIFF
--- a/createlinks-filter
+++ b/createlinks-filter
@@ -49,6 +49,7 @@ my @templates = qw(
     /etc/rspamd/forbidden_file_extension.map
     /var/lib/nethserver/sieve-scripts/before.sieve
     /etc/rspamd/local.d/external_services.conf
+    /etc/opt/olefy/olefy.conf
 );
 
 #
@@ -68,6 +69,7 @@ event_services($event, qw(
     rspamd restart
     postfix restart
     httpd-admin reload
+    olefy restart
 ));
 
 #

--- a/filter/etc/e-smith/templates/etc/opt/olefy/olefy.conf/10base
+++ b/filter/etc/e-smith/templates/etc/opt/olefy/olefy.conf/10base
@@ -1,0 +1,26 @@
+# olefy socket Configuration file
+
+OLEFY_BINDADDRESS=127.0.0.1
+OLEFY_BINDPORT=10632
+
+ # systemd PrivateTmp is used. The path will be /tmp/systemd....olefy.../tmp
+OLEFY_TMPDIR=/tmp
+
+ # no command line options allowed here
+OLEFY_PYTHON_PATH=/opt/olefy/bin/python
+ # no command line options allowed here
+OLEFY_OLEVBA_PATH=/opt/olefy/bin/olevba3
+
+ # 10:DEBUG, 20:INFO, 30:WARNING, 40:ERROR, 50:CRITICAL
+OLEFY_LOGLVL=30
+
+ # olefy will do nothing with files under MINLENGTH characters
+OLEFY_MINLENGTH=500
+
+ # 0 - do not delete tmp files, 1 - delete tmp files
+ #  regardless this setting systemd will restart the service all 4h
+ #  and creates a new PrivateTmp
+OLEFY_DEL_TMP=1
+
+ # 0 - do not delete tmp files when failed, 1 - delete tmp files when failed
+OLEFY_DEL_TMP_FAILED=1

--- a/filter/etc/e-smith/templates/etc/opt/olefy/olefy.conf/10base
+++ b/filter/etc/e-smith/templates/etc/opt/olefy/olefy.conf/10base
@@ -3,24 +3,24 @@
 OLEFY_BINDADDRESS=127.0.0.1
 OLEFY_BINDPORT=10632
 
- # systemd PrivateTmp is used. The path will be /tmp/systemd....olefy.../tmp
+# systemd PrivateTmp is used. The path will be /tmp/systemd....olefy.../tmp
 OLEFY_TMPDIR=/tmp
 
- # no command line options allowed here
+# no command line options allowed here
 OLEFY_PYTHON_PATH=/opt/olefy/bin/python
- # no command line options allowed here
+# no command line options allowed here
 OLEFY_OLEVBA_PATH=/opt/olefy/bin/olevba3
 
- # 10:DEBUG, 20:INFO, 30:WARNING, 40:ERROR, 50:CRITICAL
+# 10:DEBUG, 20:INFO, 30:WARNING, 40:ERROR, 50:CRITICAL
 OLEFY_LOGLVL=30
 
- # olefy will do nothing with files under MINLENGTH characters
+# olefy will do nothing with files under MINLENGTH characters
 OLEFY_MINLENGTH=500
 
- # 0 - do not delete tmp files, 1 - delete tmp files
- #  regardless this setting systemd will restart the service all 4h
- #  and creates a new PrivateTmp
+# 0 - do not delete tmp files, 1 - delete tmp files
+#  regardless this setting systemd will restart the service all 4h
+#  and creates a new PrivateTmp
 OLEFY_DEL_TMP=1
 
- # 0 - do not delete tmp files when failed, 1 - delete tmp files when failed
+# 0 - do not delete tmp files when failed, 1 - delete tmp files when failed
 OLEFY_DEL_TMP_FAILED=1

--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/external_services.conf/10base
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/external_services.conf/10base
@@ -7,7 +7,7 @@
 # local.d/external_services.conf
 oletools {
   # default olefy settings
-  servers = "127.0.0.1:10050"
+  servers = "127.0.0.1:10632"
 
   # needs to be set explicitly for Rspamd < 1.9.5
   scan_mime_parts = true;

--- a/nethserver-mail.spec
+++ b/nethserver-mail.spec
@@ -46,7 +46,7 @@ Requires: rspamd >= 1.9.1
 Requires: redis
 Requires: zstd
 Requires: mod_authnz_pam
-Requires: olefy
+Requires: olefy >= 1.0.1
 Obsoletes: nethserver-mail2-filter < %{obsversion}
 Provides: nethserver-mail2-filter = %{version}
 Obsoletes: nethserver-spamd < 1.0.2

--- a/nethserver-mail.spec
+++ b/nethserver-mail.spec
@@ -46,7 +46,7 @@ Requires: rspamd >= 1.9.1
 Requires: redis
 Requires: zstd
 Requires: mod_authnz_pam
-Requires: olefy >= 1.0.1
+Requires: olefy
 Obsoletes: nethserver-mail2-filter < %{obsversion}
 Provides: nethserver-mail2-filter = %{version}
 Obsoletes: nethserver-spamd < 1.0.2


### PR DESCRIPTION
The new Olefy 1.0.1 package fixes a TCP port conflict. The port 10632 is
the new (unassigned) port number.

NethServer/dev#5963