### PR TITLE
Multimap domains map must match first

### DIFF
--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/multimap.conf/10base
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/multimap.conf/10base
@@ -28,6 +28,20 @@ FROM_WHITELIST {
     symbol = "FROM_WHITELIST";
 }
 
+#whitelist the domains of senders
+FROM_DOMAINS_WHITELIST {
+  
+  map = [
+  "${CONFDIR}/whitelist_from_domains.map",
+  ];
+  type = "from";
+  prefilter = true;
+  action = "accept";
+  filter = "email:domain:tld";
+  description = "Accepted SMTP sender by top level domain name suffix";
+  symbol = "FROM_DOMAINS_WHITELIST";
+
+}
 #whitelist the sub.domains of senders
 FROM_SUBDOMAINS_WHITELIST {
 
@@ -39,21 +53,7 @@ FROM_SUBDOMAINS_WHITELIST {
     action = "accept";
     filter = "email:domain";
     description = "Accept SMTP sender by exact domain name";
-    symbol = "FROM_DOMAINS_WHITELIST";
-}
-
-#whitelist the domains of senders
-FROM_DOMAINS_WHITELIST {
-
-    map = [
-    "${CONFDIR}/whitelist_from_domains.map",
-    ];
-    type = "from";
-    prefilter = true;
-    action = "accept";
-    filter = "email:domain:tld";
-    description = "Accepted SMTP sender by top level domain name suffix";
-    symbol = "FROM_DOMAINS_WHITELIST";
+    symbol = "FROM_SUBDOMAINS_WHITELIST";
 }
 
 #blacklist the senders
@@ -67,6 +67,17 @@ FROM_BLACKLIST {
     description = "Reject SMTP sender by exact email address";
 }
 
+#blacklist the domains of senders
+FROM_DOMAINS_BLACKLIST {
+  map = [
+  "${CONFDIR}/blacklist_from_domains.map",
+  ];
+  type = "from";
+  filter = "email:domain:tld";
+  description = "Reject SMTP sender by top level domain name suffix";
+  symbol = "FROM_DOMAINS_BLACKLIST";
+}
+
 #blacklist the subdomains of senders
 FROM_SUBDOMAINS_BLACKLIST {
     map = [
@@ -75,18 +86,20 @@ FROM_SUBDOMAINS_BLACKLIST {
     type = "from";
     filter = "email:domain";
     description = "Reject SMTP sender by exact domain name";
-    symbol = "FROM_DOMAINS_BLACKLIST";
+    symbol = "FROM_SUBDOMAINS_BLACKLIST";
 }
 
-#blacklist the domains of senders
-FROM_DOMAINS_BLACKLIST {
-    map = [
-    "${CONFDIR}/blacklist_from_domains.map",
-    ];
-    type = "from";
-    filter = "email:domain:tld";
-    description = "Reject SMTP sender by top level domain name suffix";
-    symbol = "FROM_DOMAINS_BLACKLIST";
+#whitelist the domain of recipients
+TO_DOMAINS_WHITELIST {
+  map = [
+  "${CONFDIR}/whitelist_to_domains.map",
+  ];
+  type = "rcpt";
+  prefilter = true;
+  action = "accept";
+  filter = "email:domain:tld";
+  description = "Accept SMTP recipient by top level domain name suffix";
+  symbol = "TO_DOMAINS_WHITELIST";
 }
 
 #whitelist the subdomain of recipients
@@ -99,20 +112,7 @@ TO_SUBDOMAINS_WHITELIST {
     action = "accept";
     filter = "email:domain";
     description = "Accept SMTP recipient by exact domain name";
-    symbol = "TO_DOMAINS_WHITELIST";
-}
-
-#whitelist the domain of recipients
-TO_DOMAINS_WHITELIST {
-    map = [
-    "${CONFDIR}/whitelist_to_domains.map",
-    ];
-    type = "rcpt";
-    prefilter = true;
-    action = "accept";
-    filter = "email:domain:tld";
-    description = "Accept SMTP recipient by top level domain name suffix";
-    symbol = "TO_DOMAINS_WHITELIST";
+    symbol = "TO_SUBDOMAINS_WHITELIST";
 }
 
 #whitelist the email address of recipients

--- a/filter/etc/rspamd/local.d/force_actions.conf
+++ b/filter/etc/rspamd/local.d/force_actions.conf
@@ -12,6 +12,6 @@ rules {
     REJECT_FROM_BLACKLIST {
         action = "reject";
         message = "Sender email address rejected";
-        expression = "FROM_BLACKLIST | FROM_DOMAINS_BLACKLIST";
+        expression = "FROM_BLACKLIST | FROM_SUBDOMAINS_BLACKLIST | FROM_DOMAINS_BLACKLIST";
     }
 }


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/5940

Multimap map must match first, the https://github.com/NethServer/nethserver-mail/pull/172 is reverted by this change

This is due because you cannot declare the same symbol with two multimap rules (check https://github.com/NethServer/dev/issues/5940#issuecomment-563280135)

so when email:domain:tld matches first the domain.org, then the sub.domain.org is bl/wl with the good symbol ( `FROM_DOMAINS_*`). The multimap rules takes an order priority, first match, first win