### PR TITLE
Fix short account name support

### DIFF
--- a/server/etc/e-smith/events/actions/nethserver-mail-account-cleanup
+++ b/server/etc/e-smith/events/actions/nethserver-mail-account-cleanup
@@ -27,12 +27,16 @@
 #
 
 use strict;
+use Sys::Hostname;
+my ($systemName, $domainName) = split(/\./, Sys::Hostname::hostname(), 2);
 
 my $event = shift || die("Missing event argument!");
 my $account = shift || die("Missing account name argument!");
 
-my $mailHomeDir = '/var/lib/nethserver/vmail/' . $account;
+#accept user@domain format
+$account =~ s/@.*//;
 
+my $mailHomeDir = "/var/lib/nethserver/vmail/$account\@$domainName";
 if ( -d $mailHomeDir ) {
     exec('/bin/rm', '-rf', $mailHomeDir);
 } else {


### PR DESCRIPTION
The mail home directory is not deleted if the event is invoked in
short user name form.  Other actions acting on user accounts assume a
short user name is passed for historical reasons. If a long user name
form is given, the `@domain` suffix is trimmed.

NethServer/dev#6030