### PR TITLE
task_timeout must not soft reject (upstream default)

### DIFF
--- a/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/20Options
+++ b/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/20Options
@@ -58,6 +58,6 @@ hs_cache_dir = "$\{DBDIR\}/";
 task_timeout = 8s;
 
 # Emit soft reject when timeout takes place
-soft_reject_on_timeout = true;
+soft_reject_on_timeout = false;
 
 \}


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/6052

If the option is set to `false` then rspamc waits kindly the clamav db is reloaded

```
Feb  5 21:12:54 prometheus clamd[4874]: Reading databases from /var/lib/clamav
Feb  5 21:12:55 prometheus rspamd[28782]: <c3742a>; csession; rspamd_controller_check_password: allow unauthorized connection from a trusted IP 127.0.0.1
Feb  5 21:12:55 prometheus rspamd[28782]: <c3742a>; csession; rspamd_message_parse: loaded message; id: <782c3e7dd400d95f1077dc0685287d95@mlsend.com>; queue-id: <undef>; size: 42078; checksum: <7bea3d9e9f91e6bcda69366971b95eb7>
Feb  5 21:12:55 prometheus rspamd[28782]: <c3742a>; csession; rspamd_mime_part_detect_language: detected part language: en
Feb  5 21:12:55 prometheus rspamd[28782]: <c3742a>; csession; rspamd_mime_part_detect_language: detected part language: en
Feb  5 21:12:55 prometheus rspamd[28782]: <c3742a>; lua; spf.lua:185: skip SPF checks for local networks and authorized users
Feb  5 21:12:55 prometheus rspamd[28782]: <c3742a>; csession; dkim_symbol_callback: skip DKIM checks for local networks and authorized users
Feb  5 21:12:55 prometheus rspamd[28782]: <c3742a>; lua; dmarc.lua:566: skip DMARC checks as either SPF or DKIM were not checked
Feb  5 21:12:55 prometheus rspamd[28782]: <c3742a>; lua; once_received.lua:98: Skipping once_received for authenticated user or local network
Feb  5 21:13:03 prometheus rspamd[28782]: <c3742a>; csession; rspamd_task_timeout: processing of task time out: 8.0s spent; 8.0s limit; forced processing
Feb  5 21:13:03 prometheus rspamd[28782]: <c3742a>; csession; rspamd_task_write_log: id: <782c3e7dd400d95f1077dc0685287d95@mlsend.com>, ip: 127.0.0.1, from: <bounce-v6r2-1176700441765872890@mlsend.com>, (default: F (no action): [0.01/19.90] [BAYES_HAM(-2.93){99.72%;},DATE_IN_PAST(1.00){},URI_COUNT_ODD(1.00){15;},R_PARTS_DIFFER(0.55){77.9%;},HTML_SHORT_LINK_IMG_3(0.50){},MIME_GOOD(-0.10){multipart/alternative;text/plain;},HAS_LIST_UNSUB(-0.01){},FREEMAIL_ENVRCPT(0.00){gmail.com;},FREEMAIL_TO(0.00){gmail.com;},FROM_HAS_DN(0.00){},FROM_NEQ_ENVFROM(0.00){sienicka.marta@hakin9.org;bounce-v6r2-1176700441765872890@mlsend.com;},GENERIC_REPUTATION(0.00){-0.54560143555383;},HAS_PHPMAILER_SIG(0.00){},HAS_REPLYTO(0.00){sienicka.marta@hakin9.org;},MIME_TRACE(0.00){0:+;1:+;2:~;},PRECEDENCE_BULK(0.00){},RCPT_COUNT_ONE(0.00){1;},RCVD_COUNT_THREE(0.00){4;},RCVD_TLS_ALL(0.00){},REPLYTO_EQ_FROM(0.00){},TAGGED_RCPT(0.00){},TO_DN_NONE(0.00){}]), len: 42078, time: 8014.461ms, dns req: 23, digest: <3ab6231440b4587179815fd46675f1cf>, mime_rcpts: <stephane.delabrusse@gmail.com,>, file: stdin
Feb  5 21:13:03 prometheus rspamd[28782]: <c3742a>; csession; rspamd_protocol_http_reply: regexp statistics: 0 pcre regexps scanned, 7 regexps matched, 184 regexps total, 66 regexps cached, 0B scanned using pcre, 44.24KiB scanned total
Feb  5 21:13:04 prometheus dovecot: lda(toto@de-labrusse.fr): sieve: msgid=<782c3e7dd400d95f1077dc0685287d95@mlsend.com>: stored mail into mailbox 'INBOX'
Feb  5 21:13:04 prometheus getmail: msg 9669/9806 (42707 bytes) msgid 597083610/35954 from <bounce-v6r2-1176700441765872890@mlsend.com> delivered to MDA_external command dovecot-lda ()
Feb  5 21:13:04 prometheus clamd[4874]: Database correctly reloaded (6905710 signatures)
```