### PR TITLE
Handle rspamd "soft reject" responses

### DIFF
--- a/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/20Options
+++ b/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/20Options
@@ -55,7 +55,7 @@ stats_file = "${DBDIR}/stats.ucl";
 hs_cache_dir = "$\{DBDIR\}/";
 
 # Timeout for messages processing (must be larger than any internal timeout used)
-task_timeout = 8s;
+task_timeout = 20s;
 
 # Emit soft reject when timeout takes place
 soft_reject_on_timeout = true;

--- a/getmail/etc/e-smith/templates/var/lib/nethserver/sieve-scripts/before.sieve/30getmailFilter
+++ b/getmail/etc/e-smith/templates/var/lib/nethserver/sieve-scripts/before.sieve/30getmailFilter
@@ -4,7 +4,7 @@
 #
 
 # -- reject silently spam
-if header :regex ["X-Spam-Action"] ["reject"] \{
+if header :regex ["X-Spam-Action"] ["^(forced? )?reject$"] \{
     discard;
     stop;
 \}

--- a/getmail/usr/bin/rspamc-getmail
+++ b/getmail/usr/bin/rspamc-getmail
@@ -21,6 +21,6 @@
 #
 
 
-/usr/bin/rspamc "$@" | /usr/bin/sed '/^X-Spam-Error:/ q2'
+/usr/bin/rspamc "$@" | /usr/bin/sed '/^X-Spam-Error:/ q2 ; /^X-Spam-Action: soft reject$/ q3'
 
 exit $?

--- a/p3scan/usr/bin/rspamc-p3scan
+++ b/p3scan/usr/bin/rspamc-p3scan
@@ -50,6 +50,6 @@ while(<$rh>) {
     }
 }
 
-if($headers =~ /^X-Spam-Error:(.*)\r?$/m) {
+if($headers =~ /^X-Spam-Error:(.*)\r?$/m || $headers =~ /^X-Spam-Action: soft reject\r?$/m) {
     exit(74); # spamc input/output error
 }


### PR DESCRIPTION
The current code does not handle "soft reject" responses from rspamd, that might happen if ClamAV does not reply in 8 seconds (for instance).

This PR ensures an exit code is returned to getmail if a "soft reject" occurs, so the mail is not expunged from the remote server and a delivery is attempted at a later step.

It is an alternative solution to #183 

https://github.com/NethServer/dev/issues/6052