### PR TITLE
Add VszLimit property

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,7 @@ Properties:
 * ``RestrictedAccessGroup`` The value is a long group name, like ``domain
   admins@mydomain.tld``. Members of the given group can login to dovecot
   services only from trusted networks. Install the
+* ``VszLimit`` set the ``default_vsz_limit`` dovecot option, values are expressed in ``M``
   ``nethserver-mail-server-ipaccess`` package to enable this feature.
 
 p3scan example: ::

--- a/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/50vsz_limit
+++ b/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/50vsz_limit
@@ -6,6 +6,6 @@
     if ($vsz ne '') {
         $OUT .= "default_vsz_limit = $vsz M\n";
     } else {
-        $OUT .= "# Using default valude for default_vsz_limit\n";
+        $OUT .= "# Using default value for default_vsz_limit\n";
     }
 }

--- a/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/50vsz_limit
+++ b/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/50vsz_limit
@@ -1,0 +1,11 @@
+#
+# 50vsz_limit
+#
+{
+    my $vsz = $dovecot{'VszLimit'} || '';
+    if ($vsz ne '') {
+        $OUT .= "default_vsz_limit = $vsz M\n";
+    } else {
+        $OUT .= "# Using default valude for default_vsz_limit\n";
+    }
+}


### PR DESCRIPTION
When VszLimit prop is empty (default), dovecot will use its default
value for 'default_vsz_limit' option.
Otherwise, VszLimit can have an integer value expressed in 'M' unit.

This implemention preserve the current behavior and should also
avoid conflicts with existing template customs.

The VszLimit prop should be changed only when users have hundreds of
thousands mails inside the INBOX.
The evidence is an error like:

 Error: mmap() failed with file  [..]/Maildir/dovecot.index.cache: Cannot allocate memory

NethServer/dev#6118