### PR TITLE
Set MaxUserConnectionsPerIp for localhost

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,7 +198,7 @@ Properties:
 * ``LmtpInetListenerStatus {enabled,disabled}`` open a TCP socket for LMTP protocol
 * ``LogActions {enabled,disabled}`` IMAP actions logging plugin
 * ``MaxProcesses N`` maximum number of worker processes spawned by dovecot. A single user session usually requires multiple processes.
-* ``MaxUserConnectionsPerIp N`` maximum TCP connections for one user behind the same IP
+* ``MaxUserConnectionsPerIp N`` maximum TCP connections for one user behind the same IP. This number will be multplied by 5 for connections coming from localhost.
 * ``PopStatus {enabled,disabled}`` POP3 protocol switch
 * ``QuotaDefaultSize N`` Default user quota size (1 unit is 10MB)
 * ``QuotaStatus {enabled,disabled}`` General user mail quota switch

--- a/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/10limits_local
+++ b/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/10limits_local
@@ -2,5 +2,5 @@
 # 10limits_local
 #
 remote 127.0.0.1 \{
-  mail_max_userip_connections = {$dovecot{MaxUserConnectionsPerIp}*5}
+  mail_max_userip_connections = { $dovecot{'MaxUserConnectionsPerIp'} * 5 }
 \}

--- a/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/10limits_local
+++ b/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/10limits_local
@@ -1,0 +1,6 @@
+#
+# 10limits_local
+#
+remote 127.0.0.1 \{
+  mail_max_userip_connections = {$dovecot{MaxUserConnectionsPerIp}*5}
+\}


### PR DESCRIPTION
Some web mail clients can creates many connections quickly reaching
the maximum value of mail_max_userip_connection option.
This is a common situation when using WebTop with shared accounts.

This commits statically sets a limit for localhost which is 5 times
higer than the value of MaxUserConnectionsPerIp property.
Such configuration should fit most usage scenarios.

If an higher limit for localhost is needed, just increase the existing
MaxUserConnectionsPerIp property.

NethServer/dev#6118