### PR TITLE
dovecot.conf: set max_userip for all protocols

### DIFF
--- a/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/10limits
+++ b/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/10limits
@@ -4,9 +4,7 @@
 
 default_process_limit = { $dovecot{MaxProcesses} }
 
-protocol imap \{
-  mail_max_userip_connections = { $dovecot{MaxUserConnectionsPerIp} }
-\}
+mail_max_userip_connections = { $dovecot{MaxUserConnectionsPerIp} }
 
 service anvil \{
     client_limit = { 3 + ($dovecot{MaxProcesses} * 4) }


### PR DESCRIPTION
Dovecot doesn't accept an 'imap' section followed by a remote one.

This new configuration applies the global limit to all type connections without matching the protocol.

See also https://doc.dovecot.org/configuration_manual/config_file/config_file_syntax/

Following configurations are *not* valid:
```
imap {
  mail_max_userip_connections = ..
}

remote x.x.x.x {
  imap {
     mail_max_userip_connections = ..
  }
}
```

```
imap {
  mail_max_userip_connections = ..
}

remote x.x.x.x {
     mail_max_userip_connections = ..
}
```

```
imap {
  mail_max_userip_connections = ..
}

local 127.0.0.1 {
  remote 127.0.0.1 {
    mail_max_userip_connections = 60
  }
}
```

NethServer/dev#6118