### PR TITLE
Show addresses of deleted users

### DIFF
--- a/api/pseudonym/read
+++ b/api/pseudonym/read
@@ -91,6 +91,19 @@ if ($cmd eq 'list') {
         push($ret->{'pseudonyms'}, $pseudonym);
     }
 
+    # addresses of deleted users
+    foreach my $record ($adb->get_all_by_prop('type' => 'user')) {
+        my $user = $record->key;
+        next if defined($users->{$user});
+        my $full_user = $user;
+        $user =~ s/(\@.*)$//;
+        my $pseudonym = {'name' => $full_user, 'wildcard' => 0, 'builtin' => 0, 'type' => 'userDeleted'};
+        $pseudonym->{'props'}{'Access'} = 'disabled';
+        $pseudonym->{'props'}{'Account'} = [{'name' => $full_user, 'displayname' => $user, 'type' => 'userDeleted'}];
+        $pseudonym->{'props'}{'Description'} = '';
+        push($ret->{'pseudonyms'}, $pseudonym);
+    }
+
 } elsif ($cmd eq 'destinations') {
     my $name = $input->{'name'};
     my @destinations;

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -330,6 +330,7 @@
         "local_network_only_form": "Internal",
         "wildcard": "Wildcard",
         "builtin": "Built-in",
+        "user_deleted": "User deleted",
         "add_alias": "Add address",
         "external_mail_addresses": "External email addresses (one per line)",
         "description": "Description",
@@ -346,7 +347,8 @@
         "make_private": "Make internal",
         "creation_wildcard_users": "The email address will be created in all domains",
         "internal": "Internal",
-        "public": "Public"
+        "public": "Public",
+        "none": "None"
     },
     "send": {
         "menu_title": "Relay",

--- a/ui/src/views/Addresses.vue
+++ b/ui/src/views/Addresses.vue
@@ -81,8 +81,8 @@
           <template slot="table-row" slot-scope="props">
             <td class="fancy">
               <a
-                :class="[props.row.builtin ? 'builtin-color' : '']"
-                @click="props.row.builtin ? undefined : openEditAddress(props.row)"
+                :class="{'builtin-color': props.row.builtin, 'disabled-color': props.row.type == 'userDeleted'}"
+                @click="(props.row.builtin || props.row.type == 'userDeleted') ? undefined : openEditAddress(props.row)"
               >
                 <strong>{{ props.row.name}}</strong>
               </a>
@@ -95,6 +95,10 @@
                 v-if="props.row.builtin"
               >({{$t('addresses.builtin')}})</span>
               <span
+                class="span-left-margin gray"
+                v-if="props.row.type == 'userDeleted'"
+              >({{$t('addresses.user_deleted')}})</span>
+              <span
                 v-if="props.row.props.Description && props.row.props.Description.length > 0"
                 class="gray span-left-margin description"
               >{{ props.row.props.Description}}</span>
@@ -105,7 +109,7 @@
                 v-for="(a, ak) in props.row.props.Account"
                 v-bind:key="ak"
               >
-                <span :class="['fa', getIcon(a), 'span-right-icon-mg']"></span>
+                <span :class="['fa', getIcon(a), 'span-right-icon-mg', {'disabled-color': props.row.type == 'userDeleted'}]"></span>
                 {{a.displayname || a.name || '-'}}
                 <span
                   v-show="ak+1 != props.row.props.Account.length"
@@ -113,12 +117,18 @@
               </span>
             </td>
             <td class="fancy">
-              <span :class="[props.row.props.Access == 'private' ? 'fa fa-lock' : 'fa fa-globe']"></span>
-              {{props.row.props.Access == 'private' ? $t('addresses.internal') : $t('addresses.public')}}
+              <div v-if="props.row.props.Access != 'disabled'">
+                <span :class="[props.row.props.Access == 'private' ? 'fa fa-lock' : 'fa fa-globe']"></span>
+                {{props.row.props.Access == 'private' ? $t('addresses.internal') : $t('addresses.public')}}
+              </div>
+              <div v-else>
+                <span class="fa fa-ban disabled-color"></span>
+                {{$t('addresses.none')}}
+              </div>
             </td>
             <td>
               <button
-                v-if="!props.row.builtin"
+                v-if="!props.row.builtin && props.row.type != 'userDeleted'"
                 @click="openEditAddress(props.row)"
                 class="btn btn-default"
               >
@@ -135,7 +145,15 @@
                 ></span>
                 {{props.row.props.Access == 'private' ? $t('addresses.make_public') : $t('addresses.make_private')}}
               </button>
-              <div v-if="!props.row.builtin" class="dropup pull-right dropdown-kebab-pf">
+              <button
+                v-if="props.row.type == 'userDeleted'"
+                @click="openDeleteAddress(props.row)"
+                class="btn btn-default"
+              >
+                <span class="fa fa-times span-right-margin"></span>
+                {{$t('delete')}}
+              </button>
+              <div v-if="!props.row.builtin && props.row.type != 'userDeleted'" class="dropup pull-right dropdown-kebab-pf">
                 <button
                   class="btn btn-link dropdown-toggle"
                   type="button"
@@ -577,6 +595,7 @@ export default {
     getIcon(account) {
       switch (account.type) {
         case "user":
+        case "userDeleted":
           return "fa-user";
 
         case "group":
@@ -906,6 +925,13 @@ export default {
 }
 .builtin-color:hover {
   color: #ec7a08;
+  cursor: initial;
+}
+.disabled-color {
+  color: #8b8d8f;
+}
+.disabled-color:hover {
+  color: #8b8d8f;
   cursor: initial;
 }
 </style>


### PR DESCRIPTION
Show addresses of deleted users if a corresponding entry in `accounts` database exists.
The entry in `accounts` database exists if the mailbox of the user was configured (e.g. the mailbox was disabled, a custom quota was set, etc).
The address/account of a deleted user can be preserved (in order to restore its configuration whenever the related user is created again) or it can be deleted from the UI.

NethServer/dev#6164