### PR TITLE
ui. fix doc info title in relay

### DIFF
--- a/ui/src/views/Send.vue
+++ b/ui/src/views/Send.vue
@@ -288,9 +288,17 @@
                   {{newSmarthost.type === 'sender' ? $t('send.smarthost_sender'): $t('send.smarthost_recipient')}}
                   <doc-info
                     :placement="'top'"
-                    :title="$t('send.sender')"
+                    :title="$t('send.smarthost_recipient')"
                     :chapter="'sender_info'"
                     :inline="true"
+                    :class="[newSmarthost.type === 'recipient' ? '' : 'hide-doc-info']"
+                  ></doc-info>
+                  <doc-info
+                    :placement="'top'"
+                    :title="$t('send.smarthost_sender')"
+                    :chapter="'sender_info'"
+                    :inline="true"
+                    :class="[newSmarthost.type === 'sender' ? '' : 'hide-doc-info']"
                   ></doc-info>
                 </label>
                 <div class="col-sm-9">
@@ -963,5 +971,9 @@ export default {
 
 .big-name {
   font-size: 16px;
+}
+
+.hide-doc-info {
+  display: none !important;
 }
 </style>


### PR DESCRIPTION
Doc info title inside the Relay page shows always `Sender` label also if `Recipient` is selected

![Screenshot 2020-07-09 at 11 06 22](https://user-images.githubusercontent.com/6152486/87020554-4bf81b00-c1d4-11ea-876c-d3cfc468e3cc.png)
