### PR TITLE
imapsync: workaround IMAPClient password bug

### DIFF
--- a/api/imapsync/execute
+++ b/api/imapsync/execute
@@ -41,10 +41,10 @@ if ($input->{Security} eq 'tls') {
     $crypt = '';
 }
 
-
+# add double-quotes to password for Mail::IMAPClient bug
 my @imapsync =("imapsync","--host2","localhost","--port2","143","--tls2","--user2",
     $name.'*vmail',"--passfile2","/var/lib/nethserver/imapsync/vmail.pwd","--host1",$hostname,
-    "--port1",$Port,$crypt,"--user1",$username,"--password1",$password,"--timeout1","10","--justlogin","--nolog");
+    "--port1",$Port,$crypt,"--user1",$username,"--password1",'"'.$password.'"',"--timeout1","10","--justlogin","--nolog");
 
 system(@imapsync);
 

--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -67,6 +67,9 @@ if ($cmd eq 'list') {
             close $fh;
         }
 
+        # remove double-quotes: fix for Mail::IMAPClient bug
+        $password =~ s/^"//;
+        $password =~ s/"$//;
         $user->{'props'}{'hostname'} =  $idb->get_prop($_,'hostname') || '';
         $user->{'props'}{'username'} =  $idb->get_prop($_,'username') || '';
         $user->{'props'}{'password'} =  $password || '';

--- a/api/imapsync/update
+++ b/api/imapsync/update
@@ -48,7 +48,8 @@ if ($cmd eq 'update') {
     # copy remote password in readable place for vmail
     umask 027;
     open(SH, '>', "/var/lib/nethserver/imapsync/$input->{'name'}.pwd");
-    print SH $input->{'password'};
+    # add double quotes for Mail::IMAPClient bug
+    print SH '"'.$input->{'password'}.'"';
     close SH;
 
     # Find the correct security policy


### PR DESCRIPTION
From imapsync FAQ:
```
Q. On Unix, some passwords contain some weird *(),;&~ characters.
   Login fails.
...
R2. If R1 fails, with very old imapsync or old Mail::IMAPClient Perl module,
    try also using double-quotes within single-quotes. It will enclose
    the password within double-quotes in the imap LOGIN command:
```

The fix has been released on Mail::IMAPClient 3.38, while EPEL has 3.37
release

See also https://imapsync.lamiral.info/FAQ.d/FAQ.Passwords_on_Unix.txt


NethServer/dev#6233