### PR TITLE
Count messages and folders for sync stats

### DIFF
--- a/api/imapsync/count
+++ b/api/imapsync/count
@@ -1,0 +1,90 @@
+#!/usr/bin/perl
+#
+# Copyright (C) 2020 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+use NethServer::ApiTools;
+use strict;
+use warnings;
+use JSON;
+
+my $input = NethServer::ApiTools::readInput();
+
+my $hostname = $input->{'hostname'};
+my $username = $input->{'username'};
+my $name = $input->{'name'};
+my $password = $input->{'password'};
+my $Port = $input->{'Port'};
+my $Security = $input->{'Security'};
+
+# find the correct encryption
+my $crypt;
+if ($input->{Security} eq 'tls') {
+    $crypt = '--tls1';
+} elsif ($input->{Security} eq 'ssl') {
+    $crypt = '--ssl1';
+} else {
+    $crypt = '';
+}
+
+# add double-quotes to password for Mail::IMAPClient bug
+my @imapsync =("imapsync","--host2","localhost","--port2","143","--tls2","--user2",
+    $name.'*vmail',"--passfile2","/var/lib/nethserver/imapsync/vmail.pwd","--host1",$hostname,
+    "--port1",$Port,$crypt,"--user1",$username,"--password1",'"'.$password.'"',"--timeout1","10","--no-modulesversion","--justfoldersizes","--nolog");
+
+open(FH, "@imapsync|");
+
+my $ret;
+
+while (<FH>) {
+    chomp;
+    if ($_ =~ 'Host2 Nb folders') {
+       my @num = $_ =~  / (\d+)/;
+       $ret->{host2Folders} = int $num[0];
+    }
+    elsif ($_ =~ 'Host2 Nb messages') {
+       my @num = $_ =~  / (\d+)/;
+       $ret->{host2Messages} = int $num[0];
+    }
+    elsif ($_ =~ 'Host2 Total size') {
+        my @num = $_ =~  / (\d+)/;
+        $ret->{host2Sizes} = int $num[0];
+    }
+    elsif ($_ =~ 'Host1 Nb folders') {
+        my @num = $_ =~  / (\d+)/;
+        $ret->{host1Folders} = int $num[0];
+    }
+    elsif ($_ =~ 'Host1 Nb messages') {
+       my @num = $_ =~  / (\d+)/;
+       $ret->{host1Messages} = int $num[0];
+    }
+    elsif ($_ =~ 'Host1 Total size') {
+        my @num = $_ =~  / (\d+)/;
+        $ret->{host1Sizes} = int $num[0];
+    }
+}
+close(FH);
+
+if ($?) {
+     $ret->{status} = 'error';
+} else {
+     $ret->{status} = 'success';
+}
+
+print encode_json($ret);

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -484,7 +484,16 @@
         "Last_sync_status_is": "Exit status",
         "imapsync_in_progress":"an IMAP synchronization is running",
         "task_in_progress":"Background task in progress",
-        "delete_imapsync_configuration":"Delete IMAP synchronization for "
+        "delete_imapsync_configuration":"Delete IMAP synchronization for ",
+        "Messages":"Messages",
+        "Sizes":"Sizes",
+        "Folders":"Folders",
+        "RemoteAccount":"Remote account",
+        "LocalAccount":"Local account",
+        "CheckAccountDiff":"Check account differences",
+        "PleaseWait":"Please wait, it takes a while",
+        "check_differences":"Check differences",
+        "account_differences":"differences"
     },
     "docs": {
         "more_info_about": "More info about",

--- a/ui/src/views/Imapsync.vue
+++ b/ui/src/views/Imapsync.vue
@@ -905,7 +905,7 @@ export default {
               '<div class="row"><b class="col-sm-4">' +
               context.$i18n.t("imapsync.Sizes") +
               "</b>" +
-              '<span class="gray">'+success["host1Sizes"]+'</span>' +
+              '<span class="gray">'+context.$options.filters.byteFormat(success.host1Sizes)+'</span>' +
               "</div>";
             text +=
               '<div class="row"><b class="col-sm-4">' +
@@ -925,7 +925,7 @@ export default {
               '<div class="row"><b class="col-sm-4">' +
               context.$i18n.t("imapsync.Sizes") +
               "</b>" +
-              '<span class="gray">'+success["host2Sizes"]+'</span>' +
+              '<span class="gray">'+context.$options.filters.byteFormat(success.host2Sizes) +'</span>' +
               "</div>";
             text +=
               '<div class="row"><b class="col-sm-4">' +


### PR DESCRIPTION
Count the number of folders, messages, sizes of the source and destination imap server to create statistics and information for the sysadmin

![Screenshot (13)](https://user-images.githubusercontent.com/3164851/95124280-76199480-0753-11eb-9fee-cf2ab6f6303e.png)
![Screenshot (14)](https://user-images.githubusercontent.com/3164851/95128284-83d21880-0759-11eb-86d7-7a8907715674.png)


For the account in example it takes 10 seconds, for another account with 125000 emails it takes about 25 seconds to count emails, folders, size

