### PR TITLE
Imapsync exclude folders of synchronization

### DIFF
--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -128,6 +128,9 @@ if ($cmd eq 'list') {
     my $password = $input->{'password'};
     my $Port = $input->{'Port'};
     my $Security = $input->{'Security'};
+    my $exclude = $input->{'Exclude'};
+    $exclude =~ s/,/|/g;
+    $exclude = '|'.$exclude  if ($exclude ne '');
 
     # find the correct encryption
     my $crypt;
@@ -142,7 +145,9 @@ if ($cmd eq 'list') {
     # add double-quotes to password for Mail::IMAPClient bug
     my @imapsync =("imapsync","--host2","localhost","--port2","143","--tls2","--user2",
         $name.'*vmail',"--passfile2","/var/lib/nethserver/imapsync/vmail.pwd","--host1",$hostname,
-        "--port1",$Port,$crypt,"--user1",$username,"--password1",'"'.$password.'"',"--timeout1","10","--no-modulesversion","--justfoldersizes","--nolog");
+        "--port1",$Port,$crypt,"--user1",$username,"--password1",'"'.$password.'"',
+        "--exclude","'^Public Folders$|^Trash$|^Deleted Items$|^Public".$exclude."'",
+        "--timeout1","10","--no-modulesversion","--justfoldersizes","--nolog");
 
     open(FH, "@imapsync|");
 

--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -75,6 +75,7 @@ if ($cmd eq 'list') {
         $user->{'props'}{'username'} =  $idb->get_prop($_,'username') || '';
         $user->{'props'}{'password'} =  $password || '';
         $user->{'props'}{'DeleteDestination'} =  $idb->get_prop($_,'DeleteDestination') || 'disabled';
+        $user->{'props'}{'Exclude'} =  $idb->get_prop($_,'Exclude') || '';
         $user->{'props'}{'Port'} =  $idb->get_prop($_,'Port') || '143';
         $user->{'props'}{'Security'} =  $idb->get_prop($_,'Security') || 'tls';
         $user->{'props'}{'MailStatus'} =  $adb->get_prop($_,'MailStatus') || 'enabled';

--- a/api/imapsync/update
+++ b/api/imapsync/update
@@ -70,7 +70,7 @@ if ($cmd eq 'update') {
     }
 
     my $exclude = join ('|',@{$input->{'Exclude'}}) || '';
-
+    $exclude = '|'.$exclude  if ($exclude ne '');
     # write the Env file for systemd
     my $vars = qq(
     LOCALUSER=$input->{'name'}
@@ -79,7 +79,7 @@ if ($cmd eq 'update') {
     SECURITY=$crypt
     DELETE=$delete
     DELETEFOLDERS=$deletefolders
-    EXCLUDE='$exclude'
+    EXCLUDE=$exclude
     REMOTEUSERNAME=$input->{'username'});
 
     open(FH, '>', "/var/lib/nethserver/imapsync/$input->{'name'}.env");

--- a/api/imapsync/update
+++ b/api/imapsync/update
@@ -44,6 +44,7 @@ if ($cmd eq 'update') {
     )) {
         $db->set_prop($input->{'name'}, $_, $input->{$_}, type => 'imapsync');
     }
+    $db->set_prop($input->{'name'}, 'Exclude', join (',',@{$input->{'Exclude'}}));
 
     # copy remote password in readable place for vmail
     umask 027;
@@ -68,6 +69,8 @@ if ($cmd eq 'update') {
         $deletefolders = '--delete2folders';
     }
 
+    my $exclude = join ('|',@{$input->{'Exclude'}}) || '';
+
     # write the Env file for systemd
     my $vars = qq(
     LOCALUSER=$input->{'name'}
@@ -76,6 +79,7 @@ if ($cmd eq 'update') {
     SECURITY=$crypt
     DELETE=$delete
     DELETEFOLDERS=$deletefolders
+    EXCLUDE='$exclude'
     REMOTEUSERNAME=$input->{'username'});
 
     open(FH, '>', "/var/lib/nethserver/imapsync/$input->{'name'}.env");

--- a/imapsync/usr/lib/systemd/system/imapsync@.service
+++ b/imapsync/usr/lib/systemd/system/imapsync@.service
@@ -12,5 +12,5 @@ ExecStart=/usr/bin/imapsync --noauthmd5 --noreleasecheck --allowsizemismatch \
 --passfile2 /var/lib/nethserver/imapsync/vmail.pwd \
 --host1 ${REMOTEHOSTNAME} --port1 ${REMOTEPORT} ${SECURITY} --user1 ${REMOTEUSERNAME} \
 --passfile1 /var/lib/nethserver/imapsync/%i.pwd \
---exclude 'Public Folders' --exclude 'Trash' --exclude 'Deleted Items'  --exclude 'Public' \
+--exclude '^Public Folders$|^Trash$|^Deleted Items$|^Public${EXCLUDE}' \
 --logdir /var/log/imapsync

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -494,7 +494,8 @@
         "countMessages": "Count messages",
         "Synchronization_info":"Synchronization information",
         "synchronization_informations_ok": "Synchronization information has been updated",
-        "synchronization_informations_error": "Synchronization information has not been updated"
+        "synchronization_informations_error": "Synchronization information has not been updated",
+        "Exclude": "Exclude folders"
     },
     "docs": {
         "more_info_about": "More info about",
@@ -516,7 +517,8 @@
         "sender_validation": "If enabled, the sender email address (From:) must match the login user or additional addresses.",
         "lifetime": "A value of 0 means retry only once.",
         "DeleteDestination": "Delete messages in the local server that are not in the remote server. Useful for backup or pre-sync.",
-        "imapsync":"Imapsync"
+        "imapsync":"Imapsync",
+        "Exclude_Folders": "The exclusion works with regex rules, if you exclude the 'Foo' folder, all folders matching 'Foo' in the name will be excluded of synchronization. If you want to be exclusive, start the exclusion folder name by '^' and end it by '$': ^Foo$"
     },
     "mailbox": {
         "public_created_ok": "Public mailbox created successfully",

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -518,7 +518,7 @@
         "lifetime": "A value of 0 means retry only once.",
         "DeleteDestination": "Delete messages in the local server that are not in the remote server. Useful for backup or pre-sync.",
         "imapsync":"Imapsync",
-        "Exclude_Folders": "The exclusion works with regex rules, if you exclude the 'Foo' folder, all folders matching 'Foo' in the name will be excluded of synchronization. If you want to be exclusive, start the exclusion folder name by '^' and end it by '$': ^Foo$"
+        "Exclude_Folders": "The exclusion works with regular expression rules. When excluding the 'Foo' folder, all folders matching 'Foo' in the name will be excluded from the synchronization. To force an exact match, start the exclusion folder name by '^' and end it by '$' like ^Foo$. Add one entry per line."
     },
     "mailbox": {
         "public_created_ok": "Public mailbox created successfully",

--- a/ui/src/views/Imapsync.vue
+++ b/ui/src/views/Imapsync.vue
@@ -702,6 +702,7 @@ export default {
             hostname: account.props.hostname,
             username: account.props.username,
             password: account.props.password,
+            Exclude: account.props.Exclude,
             name: account.name,
             action: "sync-info"
           },

--- a/ui/src/views/Imapsync.vue
+++ b/ui/src/views/Imapsync.vue
@@ -385,6 +385,22 @@
                     >
                   </div>
                 </div>
+                <div v-if="view.advanced" class="form-group" >
+                  <label
+                  class="col-sm-3 control-label"
+                  for="textInput-modal-markup"
+                  >{{$t('imapsync.Exclude')}}
+                  <doc-info
+                    :placement="'top'"
+                    :title="$t('imapsync.Exclude')"
+                    :chapter="'Exclude_Folders'"
+                    :inline="true"
+                  ></doc-info>
+                  </label>
+                  <div class="col-sm-9">
+                      <textarea v-model="currentUser.props.Exclude" class="form-control"></textarea>
+                  </div>
+                </div>
             </div>
             <div class="modal-footer">
               <div v-if="currentUser.isLoading" class="spinner spinner-sm form-spinner-loader"></div>
@@ -512,7 +528,8 @@ export default {
           Security: "tls",
           hostname: "",
           username: "",
-          password: ""
+          password: "",
+          Exclude: ""
         },
         name: "",
         service:"stopped"
@@ -728,11 +745,15 @@ export default {
           this.currentUser.props.Security = this.previousValues.Security;
           this.currentUser.props.hostname = this.previousValues.hostname;
       }
+      // Split the Exclude for the textarea
+      this.currentUser.props.Exclude = this.currentUser.props.Exclude.split(",").join("\n");
 
       $("#editUserModal").modal("show");
     },
     editUser() {
       var context = this;
+
+      var  CleanExclude = ((context.currentUser.props.Exclude.split("\n")).filter(e => String(e).trim())).map(str => str.trim());
 
       var userObj = {
         DeleteDestination: context.currentUser.props.DeleteDestination,
@@ -742,6 +763,7 @@ export default {
         username: context.currentUser.props.username,
         password: context.currentUser.props.password,
         name: context.currentUser.name,
+        Exclude: context.currentUser.props.Exclude.length > 0 ? CleanExclude : [],
         action: "update"
       };
 


### PR DESCRIPTION
The PR provides a textarea to exclude folders from the synchronization, it match a regex rule, so all folder matching `Foo` in the name will be excluded of synchronization, to be exclusive you need to use `^Foo$`

we need a hack for the exclusion list, if you end the list with `|` then all folders are excluded. So if the exclusion exists, then we add `|` at the beginning 

https://github.com/NethServer/dev/issues/6306