### PR TITLE
Imapsync: Quote " when present in an user  password

### DIFF
--- a/api/imapsync/execute
+++ b/api/imapsync/execute
@@ -28,6 +28,8 @@ my $hostname = $input->{'hostname'};
 my $username = $input->{'username'};
 my $name = $input->{'name'};
 my $password = $input->{'password'};
+# quote double-quotes to password for Mail::IMAPClient bug
+$password =~ s/"/\\"/g;
 my $Port = $input->{'Port'};
 my $Security = $input->{'Security'};
 

--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -71,6 +71,8 @@ if ($cmd eq 'list') {
         # remove double-quotes: fix for Mail::IMAPClient bug
         $password =~ s/^"//;
         $password =~ s/"$//;
+        # remove the quote of double-quotes to password for Mail::IMAPClient bug
+        $password =~ s/\\"/"/g;
         $user->{'props'}{'hostname'} =  $idb->get_prop($_,'hostname') || '';
         $user->{'props'}{'username'} =  $idb->get_prop($_,'username') || '';
         $user->{'props'}{'password'} =  $password || '';
@@ -125,6 +127,8 @@ if ($cmd eq 'list') {
     my $username = $input->{'username'};
     my $name = $input->{'name'};
     my $password = $input->{'password'};
+    # quote double-quotes to password for Mail::IMAPClient bug
+    $password =~ s/"/\\"/g;
     my $Port = $input->{'Port'};
     my $Security = $input->{'Security'};
 

--- a/api/imapsync/update
+++ b/api/imapsync/update
@@ -44,12 +44,15 @@ if ($cmd eq 'update') {
     )) {
         $db->set_prop($input->{'name'}, $_, $input->{$_}, type => 'imapsync');
     }
+    my $password = $input->{'password'};
+    # quote double-quotes to password for Mail::IMAPClient bug
+    $password =~ s/"/\\"/g;
 
     # copy remote password in readable place for vmail
     umask 027;
     open(SH, '>', "/var/lib/nethserver/imapsync/$input->{'name'}.pwd");
     # add double quotes for Mail::IMAPClient bug
-    print SH '"'.$input->{'password'}.'"';
+    print SH '"'.$password.'"';
     close SH;
 
     # Find the correct security policy


### PR DESCRIPTION
When a user uses a `"` in a password, we breack imapsync because due to a bug in the perl library Mail::IMAPClient 3.37 we have to enclose the password inside double quote 

https://imapsync.lamiral.info/FAQ.d/FAQ.Passwords_on_Unix.txt

So we need to quote all double quote we can find in the user's password, ecept the first and the last we write in `/var/lib/nethserver/umapsync/user.pwd`

https://github.com/NethServer/dev/issues/6303
