### PR TITLE
Save the imapsync passfile in utf8

### DIFF
--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -62,7 +62,7 @@ if ($cmd eq 'list') {
         my $password;
         # the secret file may not exist
         if ( -f '/var/lib/nethserver/imapsync/'.$_.'.pwd') {
-            open my $fh, "<", '/var/lib/nethserver/imapsync/'.$_.'.pwd';
+            open my $fh, "<:utf8", '/var/lib/nethserver/imapsync/'.$_.'.pwd';
             # Read until EOF 'slurp' mode
             $password = do { local $/; <$fh> };
             close $fh;

--- a/api/imapsync/update
+++ b/api/imapsync/update
@@ -53,7 +53,7 @@ if ($cmd eq 'update') {
 
     # copy remote password in readable place for vmail
     umask 027;
-    open(SH, '>', "/var/lib/nethserver/imapsync/$input->{'name'}.pwd");
+    open(SH, '>:utf8', "/var/lib/nethserver/imapsync/$input->{'name'}.pwd");
     # add double quotes for Mail::IMAPClient bug
     print SH '"'.$password.'"';
     close SH;


### PR DESCRIPTION
The imapsync passfile must be saved in UTF8, perl do not do it explicitly.

https://github.com/NethServer/dev/issues/6308