### PR TITLE
Use passfile for the count messages features

### DIFF
--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -28,9 +28,7 @@ use JSON;
 use NethServer::Password;
 use NethServer::Service;
 use File::Copy qw/ copy /;
-use NethServer::ApiTools;
-
-require '/usr/libexec/nethserver/api/lib/helper_functions.pl';
+use NethServer::ApiTools qw(error readInput safe_decode_json);
 
 my $input = readInput();
 my $cmd = $input->{'action'};
@@ -127,9 +125,6 @@ if ($cmd eq 'list') {
     my $hostname = $input->{'hostname'};
     my $username = $input->{'username'};
     my $name = $input->{'name'};
-    my $password = $input->{'password'};
-    # quote double-quotes to password for Mail::IMAPClient bug
-    $password =~ s/"/\\"/g;
     my $Port = $input->{'Port'};
     my $Security = $input->{'Security'};
     my $exclude = $input->{'Exclude'};
@@ -146,14 +141,13 @@ if ($cmd eq 'list') {
         $crypt = '';
     }
 
-    # add double-quotes to password for Mail::IMAPClient bug
-    my @imapsync =("imapsync","--host2","localhost","--port2","143","--tls2","--user2",
+    my @imapsync =("/usr/bin/imapsync","--host2","localhost","--port2","143","--tls2","--user2",
         $name.'*vmail',"--passfile2","/var/lib/nethserver/imapsync/vmail.pwd","--host1",$hostname,
-        "--port1",$Port,$crypt,"--user1",$username,"--password1",'"'.$password.'"',
+        "--port1",$Port,$crypt,"--user1",$username,"--passfile1","/var/lib/nethserver/imapsync/".$name.".pwd",
         "--exclude","'^Public Folders$|^Trash$|^Deleted Items$|^Public".$exclude."'",
         "--timeout1","10","--no-modulesversion","--justfoldersizes","--nolog");
 
-    open(FH, "@imapsync|");
+    open(FH, "-|",@imapsync);
 
     while (<FH>) {
         chomp;

--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -60,7 +60,7 @@ if ($cmd eq 'list') {
         my $password;
         # the secret file may not exist
         if ( -f '/var/lib/nethserver/imapsync/'.$_.'.pwd') {
-            open my $fh, "<:utf8", '/var/lib/nethserver/imapsync/'.$_.'.pwd';
+            open my $fh, "<:encoding(UTF-8)", '/var/lib/nethserver/imapsync/'.$_.'.pwd';
             # Read until EOF 'slurp' mode
             $password = do { local $/; <$fh> };
             close $fh;

--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -144,7 +144,7 @@ if ($cmd eq 'list') {
     my @imapsync =("/usr/bin/imapsync","--host2","localhost","--port2","143","--tls2","--user2",
         $name.'*vmail',"--passfile2","/var/lib/nethserver/imapsync/vmail.pwd","--host1",$hostname,
         "--port1",$Port,$crypt,"--user1",$username,"--passfile1","/var/lib/nethserver/imapsync/".$name.".pwd",
-        "--exclude","'^Public Folders$|^Trash$|^Deleted Items$|^Public".$exclude."'",
+        "--exclude","^Public Folders|^Trash|^Deleted Items|^Public".$exclude,
         "--timeout1","10","--no-modulesversion","--justfoldersizes","--nolog");
 
     open(FH, "-|",@imapsync);

--- a/api/imapsync/update
+++ b/api/imapsync/update
@@ -53,7 +53,7 @@ if ($cmd eq 'update') {
 
     # copy remote password in readable place for vmail
     umask 027;
-    open(SH, '>:utf8', "/var/lib/nethserver/imapsync/$input->{'name'}.pwd");
+    open(SH, '>:encoding(UTF-8)', "/var/lib/nethserver/imapsync/$input->{'name'}.pwd");
     # add double quotes for Mail::IMAPClient bug
     print SH '"'.$password.'"';
     close SH;


### PR DESCRIPTION
For the imapsync feature about `count messages` we face two bugs

- The UI gives us back a bad string not encoded in UTF8, so when you press count messages the password `mypwd£` is given to the API in `mypwd�`
- The developers of imapsync asks when we have an old version of  Mail::IMAPClient to use quote and double quote to protect a password : `'"mypw\"d"'`

We use a passfile to turn around the bugs above, I think the simplest is now to  use the passfile too with the `count messages` feature

https://github.com/NethServer/dev/issues/6303