### PR TITLE
Allow to exclude subfolders of  synchronization

### DIFF
--- a/imapsync/usr/lib/systemd/system/imapsync@.service
+++ b/imapsync/usr/lib/systemd/system/imapsync@.service
@@ -12,5 +12,5 @@ ExecStart=/usr/bin/imapsync --noauthmd5 --noreleasecheck --allowsizemismatch \
 --passfile2 /var/lib/nethserver/imapsync/vmail.pwd \
 --host1 ${REMOTEHOSTNAME} --port1 ${REMOTEPORT} ${SECURITY} --user1 ${REMOTEUSERNAME} \
 --passfile1 /var/lib/nethserver/imapsync/%i.pwd \
---exclude '^Public Folders$|^Trash$|^Deleted Items$|^Public${EXCLUDE}' \
+--exclude '^Public Folders|^Trash|^Deleted Items|^Public${EXCLUDE}' \
 --logdir /var/log/imapsync


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/6306

The regex rule is too exclusive subfolders are included in the synchronization see https://github.com/NethServer/dev/issues/6306#issuecomment-710189784