### PR TITLE
Fix quota recalc for groups

### DIFF
--- a/server/etc/e-smith/events/actions/nethserver-mail-quota-recalc
+++ b/server/etc/e-smith/events/actions/nethserver-mail-quota-recalc
@@ -32,7 +32,6 @@ if [[ -n "$2" ]]; then
     if /usr/bin/doveadm user -u "$2" &>/dev/null; then
         exec /usr/bin/doveadm quota recalc -u "$2"
     else
-        echo "[NOTICE] Skipping quota recalc for $2: not a dovecot user."
         exit 0
     fi
 fi

--- a/server/etc/e-smith/events/actions/nethserver-mail-quota-recalc
+++ b/server/etc/e-smith/events/actions/nethserver-mail-quota-recalc
@@ -29,7 +29,12 @@ fi
 
 # Exit here if username is passed as second argument
 if [[ -n "$2" ]]; then
-    exec /usr/bin/doveadm quota recalc -u $2
+    if /usr/bin/doveadm user -u "$2" &>/dev/null; then
+        exec /usr/bin/doveadm quota recalc -u "$2"
+    else
+        echo "[NOTICE] Skipping quota recalc for $2: not a dovecot user."
+        exit 0
+    fi
 fi
 
 # Recalc quota for any existing user


### PR DESCRIPTION
Ensure a valid user is passed (and not a group name) before invoking `doveadm quota recalc`.

https://github.com/NethServer/dev/issues/6310