### PR TITLE
Decode UTF8 string of Exclude

### DIFF
--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -29,6 +29,7 @@ use NethServer::Password;
 use NethServer::Service;
 use File::Copy qw/ copy /;
 use NethServer::ApiTools qw(error readInput safe_decode_json);
+use Encode;
 
 my $input = readInput();
 my $cmd = $input->{'action'};
@@ -75,7 +76,7 @@ if ($cmd eq 'list') {
         $user->{'props'}{'username'} =  $idb->get_prop($_,'username') || '';
         $user->{'props'}{'password'} =  $password || '';
         $user->{'props'}{'DeleteDestination'} =  $idb->get_prop($_,'DeleteDestination') || 'disabled';
-        $user->{'props'}{'Exclude'} =  $idb->get_prop($_,'Exclude') || '';
+        $user->{'props'}{'Exclude'} =  decode("utf8", $idb->get_prop($_,'Exclude') || '');
         $user->{'props'}{'Port'} =  $idb->get_prop($_,'Port') || '143';
         $user->{'props'}{'Security'} =  $idb->get_prop($_,'Security') || 'tls';
         $user->{'props'}{'MailStatus'} =  $adb->get_prop($_,'MailStatus') || 'enabled';


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/6306

The Exclude  is correctly read from readInput and correctly saved inside esmith database but the exclude string read from esmith database is badly encoded and given to the UI in characters not in UTF8

