### PR TITLE
Enable the oletools extended mode

### DIFF
--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/external_services.conf/10base
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/external_services.conf/10base
@@ -11,7 +11,10 @@ oletools {
 
   # needs to be set explicitly for Rspamd < 1.9.5
   scan_mime_parts = true;
-  
+
+  # oletools extended mode
+  extended = true;
+
   # If set force this action if any virus is found (default unset: no action is forced)
   action = "reject";
 


### PR DESCRIPTION
The oletools extended mode can reject more macro when turned to true, however the default olefy rpm does not reject recent macro we could use also a fork

https://github.com/NethServer/olefy/pull/5

https://github.com/NethServer/dev/issues/6321