### PR TITLE
Dynamic exclusion of Trash folder

### DIFF
--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -76,6 +76,7 @@ if ($cmd eq 'list') {
         $user->{'props'}{'username'} =  $idb->get_prop($_,'username') || '';
         $user->{'props'}{'password'} =  $password || '';
         $user->{'props'}{'DeleteDestination'} =  $idb->get_prop($_,'DeleteDestination') || 'disabled';
+        $user->{'props'}{'TrashSync'} =  $idb->get_prop($_,'TrashSync') || 'disabled';
         $user->{'props'}{'Exclude'} =  $idb->get_prop($_,'Exclude') || '';
         $user->{'props'}{'Port'} =  $idb->get_prop($_,'Port') || '143';
         $user->{'props'}{'Security'} =  $idb->get_prop($_,'Security') || 'tls';
@@ -131,6 +132,7 @@ if ($cmd eq 'list') {
     my $exclude = $input->{'Exclude'};
     $exclude =~ s/,/|/g;
     $exclude = '|'.$exclude  if ($exclude ne '');
+    $exclude .= '|^Trash' if $input->{'TrashSync'} eq 'disabled';
 
     # find the correct encryption
     my $crypt;
@@ -145,7 +147,7 @@ if ($cmd eq 'list') {
     my @imapsync =("/usr/bin/imapsync","--host2","localhost","--port2","143","--tls2","--user2",
         $name.'*vmail',"--passfile2","/var/lib/nethserver/imapsync/vmail.pwd","--host1",$hostname,
         "--port1",$Port,$crypt,"--user1",$username,"--passfile1","/var/lib/nethserver/imapsync/".$name.".pwd",
-        "--exclude","^Public Folders|^Trash|^Deleted Items|^Public".$exclude,
+        "--exclude","^Public Folders|^Deleted Items|^Public".$exclude,
         "--timeout1","10","--no-modulesversion","--justfoldersizes","--nolog");
 
     open(FH, "-|",@imapsync);

--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -147,7 +147,7 @@ if ($cmd eq 'list') {
     my @imapsync =("/usr/bin/imapsync","--host2","localhost","--port2","143","--tls2","--user2",
         $name.'*vmail',"--passfile2","/var/lib/nethserver/imapsync/vmail.pwd","--host1",$hostname,
         "--port1",$Port,$crypt,"--user1",$username,"--passfile1","/var/lib/nethserver/imapsync/".$name.".pwd",
-        "--exclude","^Public Folders|^Deleted Items|^Public".$exclude,
+        "--exclude","^Deleted Items|^Public|^Shared".$exclude,
         "--timeout1","10","--no-modulesversion","--justfoldersizes","--nolog");
 
     open(FH, "-|",@imapsync);

--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -76,7 +76,7 @@ if ($cmd eq 'list') {
         $user->{'props'}{'username'} =  $idb->get_prop($_,'username') || '';
         $user->{'props'}{'password'} =  $password || '';
         $user->{'props'}{'DeleteDestination'} =  $idb->get_prop($_,'DeleteDestination') || 'disabled';
-        $user->{'props'}{'TrashSync'} =  $idb->get_prop($_,'TrashSync') || 'disabled';
+        $user->{'props'}{'TrashSync'} =  $idb->get_prop($_,'TrashSync') || 'enabled';
         $user->{'props'}{'Exclude'} =  $idb->get_prop($_,'Exclude') || '';
         $user->{'props'}{'Port'} =  $idb->get_prop($_,'Port') || '143';
         $user->{'props'}{'Security'} =  $idb->get_prop($_,'Security') || 'tls';

--- a/api/imapsync/read
+++ b/api/imapsync/read
@@ -132,7 +132,7 @@ if ($cmd eq 'list') {
     my $exclude = $input->{'Exclude'};
     $exclude =~ s/,/|/g;
     $exclude = '|'.$exclude  if ($exclude ne '');
-    $exclude .= '|^Trash' if $input->{'TrashSync'} eq 'disabled';
+    $exclude .= '|^Trash|^Deleted Items' if $input->{'TrashSync'} eq 'disabled';
 
     # find the correct encryption
     my $crypt;
@@ -147,7 +147,7 @@ if ($cmd eq 'list') {
     my @imapsync =("/usr/bin/imapsync","--host2","localhost","--port2","143","--tls2","--user2",
         $name.'*vmail',"--passfile2","/var/lib/nethserver/imapsync/vmail.pwd","--host1",$hostname,
         "--port1",$Port,$crypt,"--user1",$username,"--passfile1","/var/lib/nethserver/imapsync/".$name.".pwd",
-        "--exclude","^Deleted Items|^Public|^Shared".$exclude,
+        "--exclude","^Public|^Shared".$exclude,
         "--timeout1","10","--no-modulesversion","--justfoldersizes","--nolog");
 
     open(FH, "-|",@imapsync);

--- a/api/imapsync/update
+++ b/api/imapsync/update
@@ -40,6 +40,7 @@ if ($cmd eq 'update') {
         hostname
         username
         DeleteDestination
+        TrashSync
         Port
         Security
     )) {
@@ -77,6 +78,8 @@ if ($cmd eq 'update') {
 
     my $exclude = join ('|',@{$input->{'Exclude'}}) || '';
     $exclude = '|'.$exclude  if ($exclude ne '');
+    $exclude .= '|^Trash' if $input->{'TrashSync'} eq 'disabled';
+
     # write the Env file for systemd
     my $vars = qq(LOCALUSER=$input->{'name'}
 REMOTEHOSTNAME=$input->{'hostname'}

--- a/api/imapsync/update
+++ b/api/imapsync/update
@@ -78,7 +78,7 @@ if ($cmd eq 'update') {
 
     my $exclude = join ('|',@{$input->{'Exclude'}}) || '';
     $exclude = '|'.$exclude  if ($exclude ne '');
-    $exclude .= '|^Trash' if $input->{'TrashSync'} eq 'disabled';
+    $exclude .= '|^Trash|^Deleted Items' if $input->{'TrashSync'} eq 'disabled';
 
     # write the Env file for systemd
     my $vars = qq(LOCALUSER=$input->{'name'}

--- a/imapsync/usr/lib/systemd/system/imapsync@.service
+++ b/imapsync/usr/lib/systemd/system/imapsync@.service
@@ -12,5 +12,5 @@ ExecStart=/usr/bin/imapsync --noauthmd5 --noreleasecheck --allowsizemismatch \
 --passfile2 /var/lib/nethserver/imapsync/vmail.pwd \
 --host1 ${REMOTEHOSTNAME} --port1 ${REMOTEPORT} ${SECURITY} --user1 ${REMOTEUSERNAME} \
 --passfile1 /var/lib/nethserver/imapsync/%i.pwd \
---exclude '^Public Folders|^Trash|^Deleted Items|^Public${EXCLUDE}' \
+--exclude '^Public Folders|^Deleted Items|^Public${EXCLUDE}' \
 --logdir /var/log/imapsync

--- a/imapsync/usr/lib/systemd/system/imapsync@.service
+++ b/imapsync/usr/lib/systemd/system/imapsync@.service
@@ -12,5 +12,5 @@ ExecStart=/usr/bin/imapsync --noauthmd5 --noreleasecheck --allowsizemismatch \
 --passfile2 /var/lib/nethserver/imapsync/vmail.pwd \
 --host1 ${REMOTEHOSTNAME} --port1 ${REMOTEPORT} ${SECURITY} --user1 ${REMOTEUSERNAME} \
 --passfile1 /var/lib/nethserver/imapsync/%i.pwd \
---exclude '^Public Folders|^Deleted Items|^Public${EXCLUDE}' \
+--exclude '^Deleted Items|^Public|^Shared${EXCLUDE}' \
 --logdir /var/log/imapsync

--- a/imapsync/usr/lib/systemd/system/imapsync@.service
+++ b/imapsync/usr/lib/systemd/system/imapsync@.service
@@ -12,5 +12,5 @@ ExecStart=/usr/bin/imapsync --noauthmd5 --noreleasecheck --allowsizemismatch \
 --passfile2 /var/lib/nethserver/imapsync/vmail.pwd \
 --host1 ${REMOTEHOSTNAME} --port1 ${REMOTEPORT} ${SECURITY} --user1 ${REMOTEUSERNAME} \
 --passfile1 /var/lib/nethserver/imapsync/%i.pwd \
---exclude '^Deleted Items|^Public|^Shared${EXCLUDE}' \
+--exclude '^Public|^Shared${EXCLUDE}' \
 --logdir /var/log/imapsync

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -496,6 +496,7 @@
         "synchronization_informations_ok": "Synchronization information has been updated",
         "synchronization_informations_error": "Synchronization information has not been updated",
         "TrashSync": "Synchronize the Trash",
+        "DefaultExclusion": "Default exclusion",
         "Exclude": "Exclude folders"
     },
     "docs": {

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -519,6 +519,7 @@
         "lifetime": "A value of 0 means retry only once.",
         "DeleteDestination": "Delete messages in the local server that are not in the remote server. Useful for backup or pre-sync.",
         "imapsync":"Imapsync",
+        "TrashSync":"The exclusion of the Trash folder is done with the exact string '^Trash'. If you have translated it you must add manually the translation to the textarea.",
         "Exclude_Folders": "The exclusion works with regular expression rules. When excluding the 'Foo' folder, all folders matching 'Foo' in the name will be excluded from the synchronization. To force an exact match, start the exclusion folder name by '^' and end it by '$' like ^Foo$. Add one entry per line."
     },
     "mailbox": {

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -495,6 +495,7 @@
         "Synchronization_info":"Synchronization information",
         "synchronization_informations_ok": "Synchronization information has been updated",
         "synchronization_informations_error": "Synchronization information has not been updated",
+        "TrashSync": "Synchronize the Trash",
         "Exclude": "Exclude folders"
     },
     "docs": {

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -519,7 +519,7 @@
         "lifetime": "A value of 0 means retry only once.",
         "DeleteDestination": "Delete messages in the local server that are not in the remote server. Useful for backup or pre-sync.",
         "imapsync":"Imapsync",
-        "TrashSync":"The exclusion of the Trash folder is done with the exact string '^Trash'. If you have translated it you must add manually the translation to the textarea.",
+        "TrashSync":"The actual trash folder name depends on the IMAP client configuration. If the trash folder name does not start with 'Trash' or 'Deleted Items' this option has no effect.",
         "Exclude_Folders": "The exclusion works with regular expression rules. When excluding the 'Foo' folder, all folders matching 'Foo' in the name will be excluded from the synchronization. To force an exact match, start the exclusion folder name by '^' and end it by '$' like ^Foo$. Add one entry per line."
     },
     "mailbox": {

--- a/ui/src/views/Imapsync.vue
+++ b/ui/src/views/Imapsync.vue
@@ -407,6 +407,17 @@
                     >
                   </div>
                 </div>
+                <div v-if="view.advanced" class="form-group">
+                  <label
+                    class="col-sm-3 control-label"
+                    for="textInput-modal-markup"
+                  >{{$t('imapsync.DefaultExclusion')}}
+                  </label>
+                  <div class="col-sm-9 mg-top-code">
+                    <code v-if="currentUser.props.TrashSync === 'disabled'">^Public|^Shared|^Trash|^Deleted Items</code>
+                    <code v-else>^Public|^Shared</code>
+                  </div>
+                </div>
                 <div v-if="view.advanced" class="form-group" >
                   <label
                   class="col-sm-3 control-label"
@@ -1027,5 +1038,8 @@ export default {
 }
 .center {
   text-align: center;
+}
+.mg-top-code {
+  margin-top: 2px;
 }
 </style>

--- a/ui/src/views/Imapsync.vue
+++ b/ui/src/views/Imapsync.vue
@@ -385,6 +385,22 @@
                     >
                   </div>
                 </div>
+                <div v-if="view.advanced" class="form-group">
+                  <label
+                    class="col-sm-3 control-label"
+                    for="textInput-modal-markup"
+                  >{{$t('imapsync.TrashSync')}}
+                  </label>
+                  <div class="col-sm-9">
+                    <input
+                      type="checkbox"
+                      true-value="enabled"
+                      false-value="disabled"
+                      v-model="currentUser.props.TrashSync"
+                      class="form-control"
+                    >
+                  </div>
+                </div>
                 <div v-if="view.advanced" class="form-group" >
                   <label
                   class="col-sm-3 control-label"
@@ -524,6 +540,7 @@ export default {
         isLoading: false,
         props: {
           DeleteDestination: "disabled",
+          TrashSync: "disabled",
           Port: 143,
           Security: "tls",
           hostname: "",
@@ -703,6 +720,7 @@ export default {
             username: account.props.username,
             password: account.props.password,
             Exclude: account.props.Exclude,
+            TrashSync: account.props.TrashSync,
             name: account.name,
             action: "sync-info"
           },
@@ -758,6 +776,7 @@ export default {
 
       var userObj = {
         DeleteDestination: context.currentUser.props.DeleteDestination,
+        TrashSync: context.currentUser.props.TrashSync,
         Port: context.currentUser.props.Port,
         Security: context.currentUser.props.Security,
         hostname: context.currentUser.props.hostname,

--- a/ui/src/views/Imapsync.vue
+++ b/ui/src/views/Imapsync.vue
@@ -390,6 +390,12 @@
                     class="col-sm-3 control-label"
                     for="textInput-modal-markup"
                   >{{$t('imapsync.TrashSync')}}
+                  <doc-info
+                    :placement="'top'"
+                    :title="$t('imapsync.TrashSync')"
+                    :chapter="'TrashSync'"
+                    :inline="true"
+                  ></doc-info>
                   </label>
                   <div class="col-sm-9">
                     <input

--- a/ui/src/views/Imapsync.vue
+++ b/ui/src/views/Imapsync.vue
@@ -546,7 +546,7 @@ export default {
         isLoading: false,
         props: {
           DeleteDestination: "disabled",
-          TrashSync: "disabled",
+          TrashSync: "enabled",
           Port: 143,
           Security: "tls",
           hostname: "",


### PR DESCRIPTION
The Trash folder might be synchronized, depended on the need of the system administrator. The PR intends to synchronize the folder on an administrator input, the default is the Trash sync is disabled

![Screenshot (37)](https://user-images.githubusercontent.com/3164851/103549826-4429e280-4ea8-11eb-8773-f4869a06786e.png)
![Screenshot (38)](https://user-images.githubusercontent.com/3164851/103549834-47bd6980-4ea8-11eb-803f-48c49e26bc8b.png)
![Screenshot (39)](https://user-images.githubusercontent.com/3164851/103549844-4be98700-4ea8-11eb-8b7b-54cbf66ea169.png)
![Screenshot (40)](https://user-images.githubusercontent.com/3164851/103549851-4e4be100-4ea8-11eb-8f4a-03d984a09d2f.png)


https://github.com/NethServer/dev/issues/6376
