### PR TITLE
pseudonym api: do not propagate Access prop

### DIFF
--- a/api/pseudonym/update
+++ b/api/pseudonym/update
@@ -69,10 +69,6 @@ if ($cmd eq 'update-pseudonym') {
         if ($_->{'type'} eq 'public') {
             $_->{'name'} = "vmail+".$_->{'name'};
         }
-        # propagate to mailbox
-        if ($_->{'type'} eq 'user' || $_->{'type'} eq 'group') {
-            set_builtin_record($_->{'name'}, $_->{'type'}, $input->{'Access'}, $db);
-        }
         push(@accounts, $_->{'name'});
     }
     $db->set_prop($input->{'name'}, 'Account', join(",", @accounts));


### PR DESCRIPTION
When changing the Access property of group pseudonym,
the change should not be propagated to the destination aliases:
a public pseudonym can always be used to deliver messages to a private
pseudonym.

NethServer/dev#6391