### PR TITLE
Spf is now a lua plugin after 2.3 version

### DIFF
--- a/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/20Options
+++ b/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/20Options
@@ -7,7 +7,7 @@ options \{
     $OUT = "local_addrs = \[127.0.0.1, $CIDR\];\n";
 }
 {
-    $OUT .= "filters = 'chartable,dkim,spf,regexp,fuzzy_check';\n" if ($rspamd{'SpamCheckStatus'} eq 'enabled');
+    $OUT .= "filters = 'chartable,dkim,regexp,fuzzy_check';\n" if ($rspamd{'SpamCheckStatus'} eq 'enabled');
 }
 raw_mode = false;
 one_shot = false;


### PR DESCRIPTION
In log we can find this now with rspamd 2.5 version

```
Jan 26 17:24:12 ns7loc10 rspamd[4786]: <uj7j5n>; cfg; dkim_module_config: init internal dkim module
Jan 26 17:24:12 ns7loc10 rspamd[4786]: <uj7j5n>; cfg; rspamd_init_filters: requested unknown module spf
```

Originally rspamd started with C plugin that are now replaced by LUA plugin, with the version > 2.3, SPF is now  a LUA plugin

See 
https://rspamd.com/doc/modules/
`spf: checks SPF records for messages processed. Since rspamd 2.3, this C module has been removed and replaced by an equivalent Lua module.`

This plugin is enabled by default

`Jan 26 17:24:12 ns7loc10 rspamd[4786]: <uj7j5n>; cfg; rspamd_init_lua_filters: init lua module spf from /usr/share/rspamd/plugins/spf.lua; digest: 1fcdf00ca4`

https://github.com/NethServer/dev/issues/6405