### PR TITLE
Prevent self-loops in mail address destinations

### DIFF
--- a/api/pseudonym/validate
+++ b/api/pseudonym/validate
@@ -33,6 +33,23 @@ $groups =  json_decode(shell_exec("/usr/libexec/nethserver/list-groups"), true);
 $adb = new EsmithDatabase('accounts');
 $ddb = new EsmithDatabase('domains');
 
+/*
+ * Check if $destination matches $address_local_part + at least one domain among $address_domain_suffixes.
+ * If no domain suffix is specified (i.e. for a wildcard address), the list of local mail domains is considered.
+ */
+function is_external_address_selfloop($destination, $address_local_part, $address_domain_suffixes = array()) {
+    global $ddb;
+    if(!$address_domain_suffixes) {
+        $address_domain_suffixes = array_keys($ddb->getAll('domain'));
+    }
+    foreach($address_domain_suffixes as $domain) {
+        if($destination == "{$address_local_part}@{$domain}") {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
 if (strpos($cmd, 'pseudonym') !== false) {
     if ($cmd == 'create-pseudonym') {
         if ($data['name'] == 'root') {
@@ -86,15 +103,10 @@ if (strpos($cmd, 'pseudonym') !== false) {
     }
     foreach ($data['Account'] as $account) {
         if ($account['type'] == 'external') {
-            $account_local_part = substr($account['name'], 0, strpos($account['name'], '@'));
-            $account_domain_part = substr($account['name'], strpos($account['name'], '@') + 1);
-            $account_name_is_local = $ddb->getKey($account_domain_part);
             if (!$mailv->evaluate($account['name'])) {
                 $v->addValidationError('Account', 'valid_mail_address');
-            } elseif($account['name'] === $data['name']) {
-                $v->addValidationError('Account', 'unallowed_self_loop', $account['name']);
-            } elseif($account_name_is_local && trim($data['name'], '@') === $account_local_part) {
-                $v->addValidationError('Account', 'unallowed_self_loop', $account['name']);
+            } elseif(is_external_address_selfloop($account['name'], trim($data['name'], '@'), $data['domains'])) {
+                $v->addValidationError('Account', 'unallowed_self_loop');
             }
         } else if (isset($accounts[$account['type']])) {
             if (!in_array($account['name'], $accounts[$account['type']])) {

--- a/api/pseudonym/validate
+++ b/api/pseudonym/validate
@@ -88,6 +88,8 @@ if (strpos($cmd, 'pseudonym') !== false) {
         if ($account['type'] == 'external') {
             if (!$mailv->evaluate($account['name'])) {
                 $v->addValidationError('Account', 'valid_mail_address');
+            } elseif($account['name'] === $data['name']) {
+                $v->addValidationError('Account', 'unallowed_self_loop', $account['name']);
             }
         } else if (isset($accounts[$account['type']])) {
             if (!in_array($account['name'], $accounts[$account['type']])) {

--- a/api/pseudonym/validate
+++ b/api/pseudonym/validate
@@ -93,7 +93,7 @@ if (strpos($cmd, 'pseudonym') !== false) {
                 $v->addValidationError('Account', 'valid_mail_address');
             } elseif($account['name'] === $data['name']) {
                 $v->addValidationError('Account', 'unallowed_self_loop', $account['name']);
-            } elseif($account_name_is_local && $data['name'] === ($account_local_part . '@')) {
+            } elseif($account_name_is_local && trim($data['name'], '@') === $account_local_part) {
                 $v->addValidationError('Account', 'unallowed_self_loop', $account['name']);
             }
         } else if (isset($accounts[$account['type']])) {

--- a/api/pseudonym/validate
+++ b/api/pseudonym/validate
@@ -31,6 +31,7 @@ $v = new LegacyValidator($data);
 $users = json_decode(shell_exec("/usr/libexec/nethserver/list-users"), true);
 $groups =  json_decode(shell_exec("/usr/libexec/nethserver/list-groups"), true);
 $adb = new EsmithDatabase('accounts');
+$ddb = new EsmithDatabase('domains');
 
 if (strpos($cmd, 'pseudonym') !== false) {
     if ($cmd == 'create-pseudonym') {
@@ -45,7 +46,6 @@ if (strpos($cmd, 'pseudonym') !== false) {
                 $v->addValidationError('name', 'wildcard_pseudonym_already_exists', $name);
             }
         } else {
-            $ddb = new EsmithDatabase('domains');
             # check if domain is defined
             foreach ($data['domains'] as $domain) {
                 if (!$ddb->getKey($domain)) {
@@ -86,9 +86,14 @@ if (strpos($cmd, 'pseudonym') !== false) {
     }
     foreach ($data['Account'] as $account) {
         if ($account['type'] == 'external') {
+            $account_local_part = substr($account['name'], 0, strpos($account['name'], '@'));
+            $account_domain_part = substr($account['name'], strpos($account['name'], '@') + 1);
+            $account_name_is_local = $ddb->getKey($account_domain_part);
             if (!$mailv->evaluate($account['name'])) {
                 $v->addValidationError('Account', 'valid_mail_address');
             } elseif($account['name'] === $data['name']) {
+                $v->addValidationError('Account', 'unallowed_self_loop', $account['name']);
+            } elseif($account_name_is_local && $data['name'] === ($account_local_part . '@')) {
                 $v->addValidationError('Account', 'unallowed_self_loop', $account['name']);
             }
         } else if (isset($accounts[$account['type']])) {

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -564,6 +564,7 @@
         "reserved_for_builtin": "This name is reserved for built-in pseudonyms",
         "pseudonym_not_found": "Pseudonym not found",
         "account_cant_be_empty": "Destination can't be empty",
+        "unallowed_self_loop": "The destination cannot be the address itself",
         "mailbox_not_found": "Mailbox not found",
         "unsupported_type": "Unsupported destination type",
         "builtin_not_found": "Built-in pseudonym not found",


### PR DESCRIPTION
The PR adds a validation check that forbids external addresses pointing to the mail address itself.

For example, if mail address is wildcard `add@` and the local domains are `example.com` and `example.test`:
- external destination `add@other.test` is allowed
- external destination `add@example.test` is forbidden

 https://github.com/NethServer/dev/issues/6464