### PR TITLE
Remove spaces to compare DKIM

### DIFF
--- a/api/domains/read
+++ b/api/domains/read
@@ -72,6 +72,7 @@ sub readNetworkChecks
     while($expectedDkimTxt =~ m/"([^"]+)"/ig) {
         $expectedDkimRaw .= $1;
     }
+    $expectedDkimRaw =~ s/ //g; # remove spaces ;
 
     my $dkimTxt = do {
         local $/;
@@ -89,6 +90,7 @@ sub readNetworkChecks
     }
     $dkimRaw =~ s/\\;/;/g; # unescape ;
     $dkimRaw =~ s/;$//g; # chomp ending ;
+    $dkimRaw =~ s/ //g; # remove spaces ;
 
     if($!) {
         $results->{'dkim-record'} = {


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/6472

We have to remove spaces to compare between the key and the  dig output

to test the patch 

`echo '{"action":"network-checks","domain":"domain.com"}'| /usr/libexec/nethserver/api/nethserver-mail/domains/read`