### PR TITLE
Relay senders are allowed with different account on the same host

### DIFF
--- a/api/send/validate
+++ b/api/send/validate
@@ -81,9 +81,12 @@ if ($cmd == "configuration") {
     $v->declareParameter('TlsStatus', Validate::SERVICESTATUS);
     $v->declareParameter('type', $v->createValidator()->memberOf(array('sender', 'recipient')));
 
-    # Verify if the smarthost use the same account for a specific hostname (valid for sender or recipient)
+    # Verify if the smarthost use the same account for a specific hostname (valid for recipient)
       foreach ($db->getAll() as $i => $n) {
-          if (isset($n['Host']) && isset($n['Username']) && ($n['Host'] === $data['Host']) && ($data['Username'] !== $n['Username'])) {
+          if ($n['type'] === 'sender') {
+              continue;
+          }
+          elseif (isset($n['Host']) && isset($n['Username']) && ($n['Host'] === $data['Host']) && ($data['Username'] !== $n['Username'])) {
               $v->addValidationError('Host', 'Host_already_in_use_with_another_account', $n['Username']);
           }
       }


### PR DESCRIPTION
When you create a relay to send email the validation block you to use the same host with different credential. This is workable we can create manually the setting by the db command.

I propose to validate only for recipient

https://github.com/NethServer/dev/issues/6495