### PR TITLE
Fix bad esmith property for clamav (rspamd key)

### DIFF
--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/antivirus.conf/10base
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/antivirus.conf/10base
@@ -1,6 +1,6 @@
 {
-my $action = $rspamd{'antivirusAction'} || 'reject';
-my $scanSize = $rspamd{'antivirusScanSize'} || '20000000';
+my $action = $rspamd{'VirusAction'} || 'reject';
+my $scanSize = $rspamd{'VirusScanSize'} || '20000000';
 my $virusStatus = $rspamd{'VirusCheckStatus'} || 'enabled';
 my $virusAttachment = $rspamd{'VirusScanOnlyAttachment'} || 'true';
 


### PR DESCRIPTION
Rspamd uses wrong esmith property in the template /etc/rspamd/local.d/antivirus.conf

https://github.com/NethServer/dev/issues/6527