### PR TITLE
Yomi needs local.d/groups.conf as a template

### DIFF
--- a/createlinks-filter
+++ b/createlinks-filter
@@ -31,6 +31,7 @@ my @templates = qw(
     /etc/rspamd/local.d/actions.conf
     /etc/rspamd/local.d/antivirus.conf
     /etc/rspamd/local.d/greylist.conf
+    /etc/rspamd/local.d/groups.conf
     /etc/rspamd/local.d/multimap.conf
     /etc/rspamd/override.d/metrics.conf
     /etc/rspamd/local.d/settings.conf

--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/groups.conf/10NethserverGroups
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/groups.conf/10NethserverGroups
@@ -1,11 +1,10 @@
+
 #
-# This file will be overwritten by the next rpm update
-# use /etc/rspamd/override.d/file.conf' - to override the defaults
+# Set score for the symbols of the NethServer Group
 #
 
-group "nethserver" {
+group "nethserver" \{
     .include "$CONFDIR/scores.d/nethserver_group.conf"
     .include(try=true; priority=1; duplicate=merge) "$LOCAL_CONFDIR/local.d/nethserver_group.conf"
     .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/nethserver_group.conf"
-}
-
+\}

--- a/filter/etc/rspamd/scores.d/nethserver_group.conf
+++ b/filter/etc/rspamd/scores.d/nethserver_group.conf
@@ -1,6 +1,6 @@
 #
 # This file will be overwritten by the next rpm update
-# use /etc/rspamd/local.d/nethserver_group.conf' - to override the defaults
+# use /etc/rspamd/override.d/nethserver_group.conf' - to override the defaults
 #
 
 symbols = {

--- a/nethserver-mail.spec
+++ b/nethserver-mail.spec
@@ -42,7 +42,7 @@ Summary: Enforces anti-spam and anti-virus checks on any message entering the ma
 BuildArch: noarch
 Requires: %{name}-common >= %{version}, nethserver-antivirus
 Requires: nethserver-dnsmasq, nethserver-unbound
-Requires: rspamd >= 2.2
+Requires: rspamd >= 2.7
 Requires: redis
 Requires: zstd
 Requires: mod_authnz_pam
@@ -132,7 +132,7 @@ with SMTP/AUTH and StartTLS encryption.
 Summary: NethServer Email quarantine
 BuildArch: noarch
 Requires: %{name}-filter >= %{version}
-Requires: rspamd >= 1.8.0
+Requires: rspamd >= 2.7
 %description quarantine
 Quarantine (Rspamd feature) add-on for NethServer
 


### PR DESCRIPTION
We need to set score to the symbol of YOMI else we have traces in logs. Therefore this file must be a template.

this is the log traces in maillog

```
Jun 28 15:20:03 ns7dev13 rspamd[5057]: <2270b8>; proxy; lua_task_insert_result_common: symbol insertion issue: unknown symbol YOMI_CLEAN; trace: [1]:{/usr/share/rspamd/lualib/lua_scanners/yomi.lua:122 - handle_yomi_result [Lua]}; [2]:{/usr/share/rspamd/lualib/lua_scanners/yomi.lua:463 - <unknown> [Lua]};

Jun 28 15:20:00 ns7dev13 rspamd[5057]: <2270b8>; proxy; lua_task_insert_result_common: symbol insertion issue: unknown symbol YOMI_SKIPPED; trace: [1]:{/usr/share/rspamd/lualib/lua_scanners/yomi.lua:271 - fn [Lua]}; [2]:{/usr/share/rspamd/lualib/lua_scanners/yomi.lua:212 - callback [Lua]}; [3]:{/usr/share/rspamd/lualib/lua_redis.lua:917 - <unknown> [Lua]};
```


https://github.com/NethServer/dev/issues/6535