### PR TITLE
Revert "Yomi needs local.d/groups.conf as a template"

### DIFF
--- a/createlinks-filter
+++ b/createlinks-filter
@@ -31,7 +31,6 @@ my @templates = qw(
     /etc/rspamd/local.d/actions.conf
     /etc/rspamd/local.d/antivirus.conf
     /etc/rspamd/local.d/greylist.conf
-    /etc/rspamd/local.d/groups.conf
     /etc/rspamd/local.d/multimap.conf
     /etc/rspamd/override.d/metrics.conf
     /etc/rspamd/local.d/settings.conf

--- a/filter/etc/rspamd/local.d/groups.conf
+++ b/filter/etc/rspamd/local.d/groups.conf
@@ -1,10 +1,11 @@
-
 #
-# Set score for the symbols of the NethServer Group
+# This file will be overwritten by the next rpm update
+# use /etc/rspamd/override.d/file.conf' - to override the defaults
 #
 
-group "nethserver" \{
+group "nethserver" {
     .include "$CONFDIR/scores.d/nethserver_group.conf"
     .include(try=true; priority=1; duplicate=merge) "$LOCAL_CONFDIR/local.d/nethserver_group.conf"
     .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/nethserver_group.conf"
-\}
+}
+

--- a/filter/etc/rspamd/scores.d/nethserver_group.conf
+++ b/filter/etc/rspamd/scores.d/nethserver_group.conf
@@ -1,6 +1,6 @@
 #
 # This file will be overwritten by the next rpm update
-# use /etc/rspamd/override.d/nethserver_group.conf' - to override the defaults
+# use /etc/rspamd/local.d/nethserver_group.conf' - to override the defaults
 #
 
 symbols = {

--- a/nethserver-mail.spec
+++ b/nethserver-mail.spec
@@ -42,7 +42,7 @@ Summary: Enforces anti-spam and anti-virus checks on any message entering the ma
 BuildArch: noarch
 Requires: %{name}-common >= %{version}, nethserver-antivirus
 Requires: nethserver-dnsmasq, nethserver-unbound
-Requires: rspamd >= 2.7
+Requires: rspamd >= 2.2
 Requires: redis
 Requires: zstd
 Requires: mod_authnz_pam
@@ -132,7 +132,7 @@ with SMTP/AUTH and StartTLS encryption.
 Summary: NethServer Email quarantine
 BuildArch: noarch
 Requires: %{name}-filter >= %{version}
-Requires: rspamd >= 2.7
+Requires: rspamd >= 1.8.0
 %description quarantine
 Quarantine (Rspamd feature) add-on for NethServer
 


### PR DESCRIPTION
Reverts NethServer/nethserver-mail#249

The PR tried to suppress a warning that is generated on each received mail:
> lua_task_insert_result_common: symbol insertion issue: unknown symbol YOMI_CLEAN

Still, the change breaks all scores from https://github.com/nethesis/yomi-rspamd

NethServer/dev#6535