### PR TITLE
The rewrite rule of rspamd needs FollowSymlinks

### DIFF
--- a/filter/etc/httpd/admin-conf.d/rspamd.conf
+++ b/filter/etc/httpd/admin-conf.d/rspamd.conf
@@ -22,6 +22,7 @@
 # We want a full control on spam scores
 # in nethgui
 <Location ~ ^/rspamd/actions($|/)>
+    Options SymLinksIfOwnerMatch
     ProxyPass "!"
     <IfModule rewrite_module>
        # Return 200


### PR DESCRIPTION
With the split of nethserver-httpd-admin and nethserver-httpd-service we have a forbidden proxypass rule that we use to hide the scores in the rspamd UI. We have to enable the `SymLinksIfOwnerMatch` (more secure that FollowSymLinks)   to make the proxypass workable
We can find an error logged on /var/log/httpd-admin/error_log explains it:

`[rewrite:error] [pid 32170] [client 192.168.2.61:44806] AH00670: Options FollowSymLinks and SymLinksIfOwnerMatch are both off, so the RewriteRule directive is also forbidden due to its similar ability to circumvent directory restrictions : /etc/httpd/htdocs, referer: https://192.168.2.61:980/rspamd/`

![5ca846926ac4578f8c3c13d28134f3167e9a3327](https://user-images.githubusercontent.com/3164851/127879540-501fd2bd-b3c0-4614-9a65-ea6b59fe842b.png)


nethgui [allows](https://github.com/NethServer/nethserver-httpd-admin/blob/master/nethgui/etc/e-smith/templates/etc/httpd/admin-conf/httpd.conf/60NethServerManager#L9) it so when it is installed the error is not there

https://github.com/NethServer/dev/issues/6554