### PR TITLE
Default weight for the reputation plugin

### DIFF
--- a/filter/etc/rspamd/local.d/groups.conf
+++ b/filter/etc/rspamd/local.d/groups.conf
@@ -3,6 +3,33 @@
 # use /etc/rspamd/override.d/file.conf' - to override the defaults
 #
 
+# default weight for the reputation plugin
+group "reputation" {
+    symbols = {
+        "IP_REPUTATION_HAM" {
+            weight = 1.0;
+        }
+        "IP_REPUTATION_SPAM" {
+            weight = 4.0;
+        }
+
+        "DKIM_REPUTATION" {
+            weight = 1.0;
+        }
+
+        "SPF_REPUTATION_HAM" {
+            weight = 1.0;
+        }
+        "SPF_REPUTATION_SPAM" {
+            weight = 2.0;
+        }
+
+        "GENERIC_REPUTATION" {
+            weight = 1.0;
+        }
+    }
+}
+
 group "nethserver" {
     .include "$CONFDIR/scores.d/nethserver_group.conf"
     .include(try=true; priority=1; duplicate=merge) "$LOCAL_CONFDIR/local.d/nethserver_group.conf"


### PR DESCRIPTION
Following the [documentation](https://rspamd.com/doc/modules/reputation.html) the reputation plugin needs to get default weight set in the local.d/groups.conf
  
If we do not set it we have a warning seen in maillog and the default score  set is 0.0, this break the reputation plugin because it is not able to adjust the score following the reputation of the sender.


https://github.com/NethServer/dev/issues/6567