### PR TITLE
More options for MessageSizeMax to send email

### DIFF
--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -84,7 +84,7 @@
           <div class="col-sm-5">
             <vue-slider
               v-model="settings.MessageSizeMax"
-              :data="[10,20,50,100,200,500,1000]"
+              :data="[10,20,25,30,35,40,45,50,75,100,200,500,1000]"
               :use-keyboard="true"
               :tooltip="'always'"
             ></vue-slider>

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -84,7 +84,9 @@
           <div class="col-sm-5">
             <vue-slider
               v-model="settings.MessageSizeMax"
-              :data="[10,20,25,30,35,40,45,50,75,100,200,500,1000]"
+              :min="10"
+              :max="1000"
+              :interval="2"
               :use-keyboard="true"
               :tooltip="'always'"
             ></vue-slider>


### PR DESCRIPTION
Users are requesting more option to send email, we have a gap to fill between 20MB to 50MB. I added too a 75 MB option

`:data="[10,20,25,30,35,40,45,50,75,100,200,500,1000]"`

https://community.nethserver.org/t/numeric-input-field-for-maximum-message-size-or-a-finer-adjustment-in-the-slider/19147


https://github.com/NethServer/dev/issues/6592