### PR TITLE
Email sent when a user is reaching his mailbox limit

### DIFF
--- a/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/50quota
+++ b/server/etc/e-smith/templates/etc/dovecot/dovecot.conf/50quota
@@ -18,6 +18,21 @@ plugin {
   quota = maildir:Quota
   quota_rule  = *:bytes=${quotaDefaultSize}M
 }
+
+# send email warning to user when the mail box reach 80% and 95%
+plugin {
+  quota_warning = storage=95%% quota-warning 95 %u
+  quota_warning2 = storage=80%% quota-warning 80 %u
+}
+
+service quota-warning {
+  executable = script /usr/libexec/nethserver/dovecot-quota-warning
+  # use some unprivileged user for executing the quota warnings
+  user = vmail
+  unix_listener quota-warning {
+    user = vmail
+  }
+}
 EOF
 }
 

--- a/server/usr/libexec/nethserver/dovecot-quota-warning
+++ b/server/usr/libexec/nethserver/dovecot-quota-warning
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+PERCENT=$1
+USER=$2
+
+cat << EOF | /usr/libexec/dovecot/dovecot-lda -d $USER -o "plugin/quota=maildir:Quota quota:noenforcing"
+From: postmaster@$(hostname)
+Subject: Email quota warning
+
+Your mailbox is now $PERCENT% full. When you will be full, the emails will be refused by the email server.
+EOF


### PR DESCRIPTION
When a user is reaching 80 or 95% we sent to him an email to warn that the mail box will refuse more email when he will hit the 100% full

https://github.com/NethServer/dev/issues/6615