### PR TITLE
Fix type property that becomes null

### DIFF
--- a/api/pseudonym/create
+++ b/api/pseudonym/create
@@ -55,10 +55,10 @@ $record->{'Account'} = join(",", @accounts);
 
 if (scalar @$domains > 0) {
     foreach (@$domains) {
-        $db->new_record("$key\@$_", $record)
+        $db->new_record("$key\@$_", {%$record});
     }
 } else {
-    $db->new_record("$key\@", $record)
+    $db->new_record("$key\@", {%$record});
 }
 
 esmith::event::set_json_log(1);


### PR DESCRIPTION
Something Fun, the type property becomes `null` even if I can see it when I print the value of `$record` I fixed the issue by rewriting the new_record
```
[root@ns7loc9 ~]#  echo '{"action":"create-pseudonym","domains":["de-labrusse.fr","nethservertest.org"],"Description":"","Access":"public","Account":[{"name":"stephane@nethservertest.org","displayname":"stephane","type":"user"}],"name":"prout"}' | /usr/bin/setsid /usr/bin/sudo /usr/libexec/nethserver/api/nethserver-mail/pseudonym/create 
# value $record before the loop
Accountstephane@nethservertest.orgtypepseudonymDescriptionAccesspublic
# first loop iteration before new_record
Accountstephane@nethservertest.orgtypepseudonymDescriptionAccesspublic
# first loop iteration after new_record
Accountstephane@nethservertest.orgtypepseudonymDescriptionAccesspublic
# second loop iteration before new_record
Accountstephane@nethservertest.orgtypepseudonymDescriptionAccesspublic
ERROR: You should not set a config record without a type (key was prout@nethservertest.org).
# second loop iteration after new_record
Accountstephane@nethservertest.orgtypepseudonymDescriptionAccesspublic
{"steps":2,"pid":26982,"args":"","event":"pseudonym-create"}
{"step":1,"pid":26982,"action":"S05generic_template_expand","event":"pseudonym-create","state":"running"}
{"progress":"0.50","time":"0.127791","exit":0,"event":"pseudonym-create","state":"done","step":1,"pid":26982,"action":"S05generic_template_expand"}
{"step":2,"pid":26982,"action":"S30nethserver-mail-postmap-update","event":"pseudonym-create","state":"running"}
{"progress":"1.00","time":"0.114145","exit":0,"event":"pseudonym-create","state":"done","step":2,"pid":26982,"action":"S30nethserver-mail-postmap-update"}
{"pid":26982,"status":"success","event":"pseudonym-create"}
```
https://github.com/NethServer/dev/issues/6636