### PR TITLE
Increase clamav and task timeout

### DIFF
--- a/filter/etc/e-smith/templates/etc/rspamd/local.d/antivirus.conf/10base
+++ b/filter/etc/e-smith/templates/etc/rspamd/local.d/antivirus.conf/10base
@@ -33,8 +33,8 @@ clamav \{
 
   # Timeout and retransmits increased in case of clamav is reloading its database
   # It takes a lot of time (25 to 60 seconds), after rspamd answers a temporally failure
-  #timeout = 5;
-  #retransmits = 2;
+  timeout = 45;
+  retransmits = 1;
 
   # servers to query (if port is unspecified, scanner-specific default is used)
   # can be specified multiple times to pool servers

--- a/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/20Options
+++ b/filter/etc/e-smith/templates/etc/rspamd/rspamd.conf/20Options
@@ -55,7 +55,7 @@ stats_file = "${DBDIR}/stats.ucl";
 hs_cache_dir = "$\{DBDIR\}/";
 
 # Timeout for messages processing (must be larger than any internal timeout used)
-task_timeout = 20s;
+task_timeout = 91s;
 
 # Emit soft reject when timeout takes place
 soft_reject_on_timeout = true;


### PR DESCRIPTION
Clamav timeout is 90 seconds (45s x 2, due to 1 retransmit).
Task timeout should be greater (91s).

90 seconds spent during an SMTP transaction are common.
Note that a bigger timeout with less retransmit is more resource efficient.

https://github.com/NethServer/dev/issues/6659