### PR TITLE
ui. refresh selectpicker on openCreateAddress

### DIFF
--- a/ui/src/views/Addresses.vue
+++ b/ui/src/views/Addresses.vue
@@ -694,7 +694,7 @@ export default {
     openCreateAddress() {
       this.newAddress = this.initAddress();
       setTimeout(function() {
-        $(".selectpicker").selectpicker();
+        $(".selectpicker").selectpicker('refresh');
       }, 50);
 
       $("#newAddressModal").modal("show");


### PR DESCRIPTION
Refresh openCreateAddress selectpicker to avoid inconsistent view after adding first address. Refer to https://github.com/NethServer/dev/issues/6739