### PR TITLE
Suppressing SMTP Smuggling / CVE-2023-51764

### DIFF
--- a/server/etc/e-smith/templates/etc/postfix/main.cf/30smtpd_data_restrictions
+++ b/server/etc/e-smith/templates/etc/postfix/main.cf/30smtpd_data_restrictions
@@ -1,0 +1,9 @@
+#
+# 30smtpd_data_restrictions -- Suppressing SMTP Smuggling
+# 
+# Postfix 2.x will not receive patches. 
+# This is the workaround as per https://www.postfix.org/smtp-smuggling.html
+#
+smtpd_data_restrictions = reject_unauth_pipelining
+smtpd_discard_ehlo_keywords = chunking, silent-discard
+


### PR DESCRIPTION
The CVE might only be 5.3 but in the light of the majority of attacks being based on phishing/social engineering and an almost endless combination possibilities when email servies are self-hosted, I rather have this mitigated.

Please consider this PR.

BR Jens